### PR TITLE
add file path to tag of json-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the prototype for LOBSTER, which is a key
 ingredient to make TRCL more useful.
 
 It has tools to extract tracing tags from a variety of sources combine
-them and produce a tracing report. The [the TRLC tracing
+them and produce a tracing report. The [TRLC tracing
 report](https://bmw-software-engineering.github.io/trlc/tracing.html)
 from the [TRLC
 Project](https://github.com/bmw-software-engineering/trlc/) is a

--- a/lobster/tools/json/json.py
+++ b/lobster/tools/json/json.py
@@ -175,7 +175,7 @@ class LOBSTER_Json(LOBSTER_Per_File_Tool):
 
                 l_item = Activity(
                     tag       = Tracing_Tag(namespace = "json",
-                                            tag       = item_name),
+                                            tag       = "%s.%s" % (file_name.replace("/", "."), item_name)),
                     location  = File_Reference(file_name),
                     framework = "JSON",
                     kind      = "Test Vector")


### PR DESCRIPTION
- Include file path in tag of json-tests in lobster-json.
  Test names are only unique within one json file, but this does not hold globally across all input files.
  Hence the test tag is modified to contain the file path, where `/` is replaced by `.`. This replacement of characters serves to improve the readability of the tags in the lobster report.
- Fix typo in readme file.