### PR TITLE
Extend lobster-python readme

### DIFF
--- a/lobster/tools/python/python.py
+++ b/lobster/tools/python/python.py
@@ -141,7 +141,7 @@ class Python_Class(Python_Traceable_Node):
         for node in self.children:
             node.to_lobster(schema, class_contents)
 
-        # If we're extracting pyunit items, then we always ignore
+        # If we're extracting pyunit/unittest items, then we always ignore
         # classes, but we do add our tags to all the tests.
         if schema is Activity:
             for item in class_contents:

--- a/packages/lobster-tool-python/README.md
+++ b/packages/lobster-tool-python/README.md
@@ -5,23 +5,23 @@ The **L**ightweight **O**pen **B**MW **S**oftware **T**raceability
 and requirements coverage, which is essential for meeting standards
 such as ISO 26262.
 
-This package contains a tool extract tracing tags from Python3 source
+This package contains a tool to extract tracing tags from Python3 source
 code.
 
 ## Tools
 
-* `lobster-python`: Extrat requirements from Python3 code
+* `lobster-python`: Extract requirements from Python3 code
 
 ## Usage
 
-This tool supports both Python code and PyUnit unit tests.
+This tool supports both Python code and PyUnit/unittest unit tests.
 
 For either code or tests you can embedd tracing tags like this:
 
 ```python
    def potato(self):
       # lobster-trace: something.example
-	  return "potato"
+      return "potato"
 ```
 
 You can add justifications as well:
@@ -29,10 +29,10 @@ You can add justifications as well:
 ```python
    def potato(self):
       # lobster-exclude: a very good reason is here
-	  return "potato"
+      return "potato"
 ```
 
-For classes you have a choice on how you trace them: you either
+For classes, you have a choice on how you trace them: you either
 annotate the class itself, or each individual method. If you choose to
 annotate the class itself, then you will get warnings for each method
 with an annotation.
@@ -43,15 +43,28 @@ For normal code the usage is:
 lobster-python FILES_OR_DIRS
 ```
 
-For pyunit the usage is:
+Note that `FILES_OR_DIRS` should not contain any tests.
+They will be treated as regular code otherwise.
+
+For tests (`pyunit` or `unittest`) the usage is:
 
 ```bash
 lobster-python --activity FILES_OR_DIRS
 ```
 
-For pyunit the tool automatically ignore any class function that is
+Here `FILES_OR_DIRS` may contain additional code (like the implementation of mock classes), but it will be ignored.
+
+For `pyunit` and `unittest` the tool automatically ignores any class function that is
 not explicitly a test (i.e. you don't need to manually exclude your
 setup or tear down code, only individual tests will be included).
+
+Please note that the generated output json files always use `PyTest` as framework indicator, even if `unittest` is used:
+```json
+{
+  "framework": "PyUnit",
+  "kind": "Test"
+}
+```
 
 ## Copyright & License information
 


### PR DESCRIPTION
- extend instructions how to extract tests
- add hint that it works with `unittest`, too

Issue: #20