### PR TITLE
Lobster supports items without summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ### 0.9.17-dev
 
+* The `lobster-html-report` tool now supports argument `--dot` to specify
+  the path to the graphviz dot utility instead of expecting it in PATH
+
+* The `lobster-online-report` tool now supports argument `--out` to specify 
+  the output file instead of editing the input report
+
+* Adds `with kind` and `with prefix` functionality in lobster.conf files
 
 ### 0.9.16
 

--- a/docs/config_files.md
+++ b/docs/config_files.md
@@ -40,7 +40,7 @@ LOBSTER source file corresponds to the TRLC requirements type.
 
 Using `with prefix <string>` allows to filter items with a certain
 prefix in the `tag` attribute in the LOBSTER source file. For TRLC 
-requirements the tag attribute corresponds to the requiremet name.
+requirements the tag attribute corresponds to the requirement name.
 
 Specifically for requirements you can say:
 

--- a/lobster/tools/codebeamer/codebeamer.py
+++ b/lobster/tools/codebeamer/codebeamer.py
@@ -196,9 +196,6 @@ def to_lobster(cb_config, cb_item):
         text      = None,
         status    = status)
 
-    if "name" not in cb_item:
-        req.error("Item lacks a summary text")
-
     return req
 
 


### PR DESCRIPTION
Item summary text guard has been removed

Resolved https://github.com/bmw-software-engineering/lobster/issues/47