### PR TITLE
Lobster-codebeamer supports items without summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### 0.9.17
 
+* The `lobster-codebeamer` tool now allows items without summary
+
 * The `lobster-python` tool now adds the line number to the function
   identifier. This supports situations where different functions have
   the same name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 0.9.18-dev
 
+* The `lobster-codebeamer` tool now allows items without summary
+
 * The `lobster-codebeamer` tool now uses codebeamer api v3.
   Please note that the api v3 returns the value "Unset" for a codebeamer
   item status if the status is actually empty. The api v1 did not return
@@ -11,13 +13,7 @@
   resulting lobster file will now contain "Unset" as status information,
   too, instead of `Null`.
 
-### 0.9.18-dev
-
-
-
 ### 0.9.17
-
-* The `lobster-codebeamer` tool now allows items without summary
 
 * The `lobster-python` tool now adds the line number to the function
   identifier. This supports situations where different functions have

--- a/lobster/tools/codebeamer/codebeamer.py
+++ b/lobster/tools/codebeamer/codebeamer.py
@@ -196,9 +196,6 @@ def to_lobster(cb_config, cb_item):
         text      = None,
         status    = status)
 
-    if "name" not in cb_item:
-        req.error("Item lacks a summary text")
-
     return req
 
 


### PR DESCRIPTION
Item summary text guard has been removed

Resolves https://github.com/bmw-software-engineering/lobster/issues/47