### PR TITLE
specifies github runner images explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
   lint:
     name: PyLint
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip --break-system-packages
-          python3 -m pip install -r requirements_dev.txt --break-system-packages
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements_dev.txt
           make lobster/html/assets.py
       - name: Executing linter
         run: |
@@ -29,7 +29,7 @@ jobs:
     if: success()
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
         py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: macos-13

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
 
   package:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9
@@ -38,7 +38,7 @@ jobs:
   upload-test:
     name: PyPI Upload
     needs: package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION
due to https://github.com/actions/runner-images/commit/e065c9ac282b89ce756801c56922614b998f0cbe the CI failed because somer runner images were set to ubuntu-latest

due to the fix https://github.com/actions/runner-images/commit/f3ad9cadef4f7c3609820a2396df4f9d662876f5 ![Endpoint Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fijunaidm%2F0b5459bbe18604a639e1d2f7accd204f%2Fraw%2Fubuntu24.json) there is no explicit argument `--break-system-packages` needed anymore