### PR TITLE
detect duplicate class method

### DIFF
--- a/lobster/tools/python/python.py
+++ b/lobster/tools/python/python.py
@@ -38,17 +38,45 @@ func_name = []
 
 def count_occurrence_of_last_function_from_function_name_list(function_names):
     """
-    Function returns a function name
-    (last function from the list of function names)
-    and its occurrence from the given list of function names
-    Example: function_names = ['hello.add:2', 'hello.sub:5', 'hello.add:8']
-             returns : hello.add-2
+    Returns the last function and class name (if present) in a list along with
+    the count of its previous occurrences.
+
+    The function identifies the last entry in the `function_names` list, extracts
+    the function and class names (if applicable), and counts prior occurrences of
+    the same function.
+    The result is formatted as `module.class.function-count` or `module.function-count`.
+
+    Args:
+        function_names (list):
+            List of strings formatted as `module.class.function:line_number`
+            or `module.function:line_number`.
+
+    Returns:
+        str: The last function (and class if applicable) with its occurrence count,
+             formatted as `module.class.function-count` or `module.function-count`.
+
+    Examples:
+        function_names = ['hello.add:2', 'hello.sub:5', 'hello.add:8']
+        returns: 'hello.add-2'
+        class_function_names = ['Example.hello.add:2', 'Example.hello.sub:5',]
+        returns: 'Example.hello.add-2'
     """
     function_and_file_name = re.split(r"[.:]", function_names[-1])
+    class_name_with_module = function_names[-1].split(':', 1)[0].split(".")
+
+    if len(class_name_with_module) == 3:
+        function_and_file_name[1] = (class_name_with_module[1] + '.' +
+                                     class_name_with_module[2])
+
     filename = function_and_file_name[0]
     last_function = function_and_file_name[1]
     count = 0
     for element in range(0, len(function_names) - 1):
+        class_name_with_function = function_names[element].split(':', 1)[0].split(".")
+        if len(class_name_with_function) == 3:
+            if last_function == (class_name_with_function[1] + '.' +
+                                 class_name_with_function[2]):
+                count += 1
         if re.split(r"[.:]", function_names[element])[1] == last_function:
             count += 1
     function_name = (filename + "." + last_function +

--- a/test-system/lobster-python/basic.output
+++ b/test-system/lobster-python/basic.output
@@ -21,14 +21,14 @@ Written output for 3 items to basic.lobster
       "kind": "Function"
     },
     {
-      "tag": "python basic.Example",
+      "tag": "python basic.Example.helper_function",
       "location": {
         "kind": "file",
         "file": "basic.py",
         "line": 13,
         "column": null
       },
-      "name": "basic.Example",
+      "name": "basic.Example.helper_function",
       "messages": [],
       "just_up": [],
       "just_down": [],
@@ -40,14 +40,14 @@ Written output for 3 items to basic.lobster
       "kind": "Method"
     },
     {
-      "tag": "python basic.Example-1",
+      "tag": "python basic.Example.nor",
       "location": {
         "kind": "file",
         "file": "basic.py",
         "line": 17,
         "column": null
       },
-      "name": "basic.Example",
+      "name": "basic.Example.nor",
       "messages": [],
       "just_up": [],
       "just_down": [],


### PR DESCRIPTION
This pull request addresses an issue where the `ref_down` section in the `lobster.report` is incorrectly reflecting class references in the `.py` file.

Changes Made:

-     Updated the method tracing logic to correctly capture and display method names in the `ref_down`  section of the 
      `lobster.report`. This ensures accurate tracking of references in accordance with the expected output.
-     This change resolves the issue of incorrect method referencing in reports and improves the traceability of code references in 
       the generated `lobster.report`.

Issue #89 