### PR TITLE
fixes dependencies in metapackage when building wheel file

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,9 +31,7 @@ jobs:
           name: wheels
           path: |
             packages/*/dist/*.whl
-            packages/*/dist/*.gz
             packages/*/meta_dist/*.whl
-            packages/*/meta_dist/*.gz
 
   upload-test:
     name: PyPI Upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Changelog
 
 
-### 1.0.0-dev
+### 0.9.19-dev
 
+* Fixes packaging of `bmw-lobster`.
 
 ### 0.9.18
 

--- a/lobster/version.py
+++ b/lobster/version.py
@@ -17,10 +17,11 @@
 # License along with this program. If not, see
 # <https://www.gnu.org/licenses/>.
 
-VERSION_TUPLE = (1, 0, 0)
+VERSION_TUPLE = (0, 9, 19)
 VERSION_SUFFIX = "dev"
 
-LOBSTER_VERSION = ("%u.%u.%u" % VERSION_TUPLE) + \
-    ("-%s" % VERSION_SUFFIX if VERSION_SUFFIX else "")
+LOBSTER_VERSION = ("%u.%u.%u" % VERSION_TUPLE) + (
+    "-%s" % VERSION_SUFFIX if VERSION_SUFFIX else ""
+)
 
 FULL_NAME = "LOBSTER %s" % LOBSTER_VERSION

--- a/packages/lobster-core/Makefile
+++ b/packages/lobster-core/Makefile
@@ -6,4 +6,4 @@ package:
 	cp -Rv $(LOBSTER_ROOT)/lobster/html lobster
 	cp $(LOBSTER_ROOT)/lobster/tools/*.py lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/core lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-metapackage/Makefile
+++ b/packages/lobster-metapackage/Makefile
@@ -1,2 +1,2 @@
 package:
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-monolithic/Makefile
+++ b/packages/lobster-monolithic/Makefile
@@ -1,5 +1,5 @@
 package:
 	rm -rf lobster dist meta_dist
 	cp -Rv $(LOBSTER_ROOT)/lobster lobster
-	@python3 -m build
+	@python3 -m build --wheel
 	mv dist meta_dist

--- a/packages/lobster-tool-codebeamer/Makefile
+++ b/packages/lobster-tool-codebeamer/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/codebeamer lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-tool-cpp/Makefile
+++ b/packages/lobster-tool-cpp/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/cpp lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-tool-cpptest/Makefile
+++ b/packages/lobster-tool-cpptest/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/cpptest lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-tool-gtest/Makefile
+++ b/packages/lobster-tool-gtest/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/gtest lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-tool-json/Makefile
+++ b/packages/lobster-tool-json/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/json lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-tool-python/Makefile
+++ b/packages/lobster-tool-python/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/python lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel

--- a/packages/lobster-tool-python/README.md
+++ b/packages/lobster-tool-python/README.md
@@ -71,7 +71,7 @@ Please note that the generated output json files always use `PyTest` as framewor
 The resulting lobster file does not use the method names, but instead uses the class name together with an integer counter for consecutive methods.
 This only affects methods in a class.
 It does not affect functions.
-For details see see [issue 89](https://github.com/bmw-software-engineering/lobster/issues/89).
+For details see [issue 89](https://github.com/bmw-software-engineering/lobster/issues/89).
 It will be fixed with the next release.
 
 ## Copyright & License information

--- a/packages/lobster-tool-trlc/Makefile
+++ b/packages/lobster-tool-trlc/Makefile
@@ -2,4 +2,4 @@ package:
 	rm -rf lobster
 	mkdir -p lobster/tools
 	cp -Rv $(LOBSTER_ROOT)/lobster/tools/trlc lobster/tools
-	@python3 -m build
+	@python3 -m build --wheel


### PR DESCRIPTION
using `python3 -m build` will first build the sdist (tar.gz file) and then use that package it to build a .whl file.
In this process it is not possible to [glob](https://github.com/bmw-software-engineering/lobster/blob/981b2f5e5ecbe89feaeffe38eb2f3c9b1dc6ae41/packages/lobster-metapackage/setup.py#L40) all other tools as dependencies anymore, because they are not available in the sdist package

since we are using `from lobster import version` in the setup.py files anyway, we need to have module lobster available in order to build the tools from sdist (tar.gz file). You cannot build the tool from source solely by using tar.gz file because of that. This is contrary to the purpose of sdist.

Suggestion: Get rid of sdist, don't build and don't provide it on pypi (don't upload it) -> this is consistent to TRLC
We will only provide .whl files
Therefore we can use `python3 -m build --wheel` explicitly to build .whl files from the source code instead of the previous build sdist package