### PR TITLE
Silently skip unrelated gtest XML entries

### DIFF
--- a/lobster/tools/gtest/gtest.py
+++ b/lobster/tools/gtest/gtest.py
@@ -76,7 +76,8 @@ def main():
             assert suite.tag == "testsuite"
             suite_name = suite.attrib["name"]
             for testcase in suite:
-                assert testcase.tag == "testcase"
+                if testcase.tag != "testcase":
+                    continue
                 test_name     = testcase.attrib["name"]
                 test_executed = testcase.attrib["status"] == "run"
                 test_ok       = True


### PR DESCRIPTION
G-Test XML files may contain XML nodes other than `testcase`. `lobster-gtest` now silently skips those, and analyses only `testcase`.