### PR TITLE
Lobster-cpptest shall output absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 0.9.20-dev
 
+* `lobster-cpptest` writes absolute paths into its `*.lobster` output files instead of
+  paths relative to the current working directory.
+
 * If a `*.lobster` file contains a tag more than once, then an error message
   ("duplicated definition") is printed for each consecutive entry with the same tag,
   instead of printing it just for the first entry.

--- a/lobster/tools/cpptest/cpptest.py
+++ b/lobster/tools/cpptest/cpptest.py
@@ -220,7 +220,6 @@ def create_lobster_items_output_dict_from_test_cases(
          The lobster items dictionary for the given test cases
          grouped by configured output.
     """
-    prefix = os.getcwd()
     lobster_items_output_dict = {}
 
     no_marker_output_file_name = ''
@@ -239,7 +238,7 @@ def create_lobster_items_output_dict_from_test_cases(
 
     for test_case in test_case_list:
         function_name: str = test_case.suite_name
-        file_name = os.path.relpath(test_case.file_name, prefix)
+        file_name = os.path.abspath(test_case.file_name)
         line_nr = int(test_case.docu_start_line)
         function_uid = "%s:%s:%u" % (os.path.basename(file_name),
                                      function_name,

--- a/tests-unit/lobster-cpptest/test_cpptest.py
+++ b/tests-unit/lobster-cpptest/test_cpptest.py
@@ -1,4 +1,5 @@
 import os
+import json
 import unittest
 from os.path import dirname
 from pathlib import Path
@@ -240,6 +241,15 @@ class LobsterCpptestTests(unittest.TestCase):
         file_exists = os.path.exists(self.output_file_name)
         self.assertTrue(file_exists)
 
+        # Open and read the JSON output file to validate all file paths are absolute
+        with open(self.output_file_name, 'r') as output_file:
+            data = json.load(output_file)
+            tag_list = data.get('data')
+
+            for tag in tag_list:
+                file_name = tag.get('location').get('file')
+                self.assertTrue(os.path.isabs(file_name))
+
     def test_single_directory(self):
         file_dir_list = [self.test_data_dir]
 
@@ -333,6 +343,8 @@ class LobsterCpptestTests(unittest.TestCase):
         for lobster_item in unit_test_lobster_items:
             self.assertIsNotNone(lobster_item)
             self.assertIsInstance(lobster_item, dict)
+            file_name = lobster_item.get('location').get('file')
+            self.assertTrue(os.path.isabs(file_name))
             tag = lobster_item.get('tag')
             refs = lobster_item.get('refs')
             self.assertIsInstance(refs, list)
@@ -361,6 +373,8 @@ class LobsterCpptestTests(unittest.TestCase):
         for lobster_item in component_test_lobster_items:
             self.assertIsNotNone(lobster_item)
             self.assertIsInstance(lobster_item, dict)
+            file_name = lobster_item.get('location').get('file')
+            self.assertTrue(os.path.isabs(file_name))
             tag = lobster_item.get('tag')
             refs = lobster_item.get('refs')
             self.assertIsInstance(refs, list)


### PR DESCRIPTION
Lobster-cpptest shall output absolute paths
Lobster-cpptest implementation ant unit tests have been adapted.

Resolves https://github.com/bmw-software-engineering/lobster/issues/135