### PR TITLE
Supporting Bazel 8 in CI

### DIFF
--- a/tests-integration/projects/basic/Makefile
+++ b/tests-integration/projects/basic/Makefile
@@ -21,7 +21,7 @@ cppcode.lobster: foo.h foo.cpp
 		--out="cppcode.lobster" --clang-tidy $(CLANG_TIDY)
 
 gtests.lobster: foo.h foo.cpp test.cpp
-	@bazel test foo_test --cxxopt='-std=c++14'
+	@bazel test foo_test --cxxopt='-std=c++14' --enable_workspace
 	@lobster-gtest $(LOBSTER_ROOT)/bazel-out/*/testlogs/$(THIS_TEST) \
 		--out="gtests.lobster"
 	sed -i s/$(THIS_TEST_ESCAPED)\\///g gtests.lobster


### PR DESCRIPTION
The CI uses Bazel 8, but we are still using WORKSPACES in our setup. Bazel 8 disables WORKSPACES by default.
Hence adding `--enable_workspace` to restore the behavior of Bazel 7.