### PR TITLE
Pin Bazel to version 8.0.0 in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
         with:
           path: ~/work/lobster/llvm-project/build/bin/clang-tidy
           key: cache-clang-tidy
+      - name: Setup bazel (for lobster-gtest)
+        uses: jwlawson/actions-setup-bazel@v2
+        with:
+          bazel-version: '8.0.0'
       - name: Run integration tests
         run: |
           make integration-tests


### PR DESCRIPTION
Explicitly set Bazel version so that future updates of Bazel will not affect our CI.