### PR TITLE
Fix typo

### DIFF
--- a/tests-system/README.md
+++ b/tests-system/README.md
@@ -21,7 +21,7 @@ expected-output/
 
 ```
 
-The target `make system-tests` in the root `~Makefile` sets the current working
+The target `make system-tests` in the root `Makefile` sets the current working
 directory of the tool under test to the `input` folder.
 
 The files must contain the following piece of information:


### PR DESCRIPTION
Fixed a typo in a `README.md` file.