### PR TITLE
Added feature: query string support through config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ full-release:
 coverage:
 	coverage combine -q
 	coverage html --rcfile=coverage.cfg
-	coverage report --rcfile=coverage.cfg --fail-under=66
+	coverage report --rcfile=coverage.cfg --fail-under=69
 
 test: system-tests unit-tests
 	make coverage

--- a/lobster/tools/codebeamer/codebeamer.py
+++ b/lobster/tools/codebeamer/codebeamer.py
@@ -534,16 +534,18 @@ def main():
 
     elif cb_config.get("import_query"):
         try:
-            if isinstance(cb_config["import_query"], int):
-                cb_config["import_query"] = int(cb_config["import_query"])
-                if cb_config["import_query"] < 0:
-                    ap.error("import-query must be a positive integer")
+            if (isinstance(cb_config["import_query"], int) and
+                cb_config["import_query"] < 0):
+                ap.error("import-query must be a positive integer")
             elif isinstance(cb_config["import_query"], str):
-                if (cb_config["import_query"].startswith("-") and
-                    cb_config["import_query"][1:].isdigit()):
-                    ap.error("import-query must be a positive integer")
-                elif cb_config["import_query"].startswith("-"):
-                    ap.error("import-query must be a valid cbQL query")
+                if cb_config["import_query"].startswith("-"):
+                    if cb_config["import_query"][1:].isdigit():
+                        ap.error("import-query must be a positive integer")
+                    else:
+                        ap.error("import-query must be a valid cbQL query")
+                elif cb_config["import_query"][1:].isdigit():
+                    cb_config["import_query"] = int(cb_config["import_query"])
+                    
         except ValueError as e:
             ap.error(str(e))
 

--- a/tests-unit/lobster-codebeamer/test_codebeamer.py
+++ b/tests-unit/lobster-codebeamer/test_codebeamer.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from lobster.tools.codebeamer.codebeamer import get_single_item, get_many_items, to_lobster, \
-    import_tagged
+from lobster.tools.codebeamer.codebeamer import get_query, get_single_item, get_many_items, to_lobster, import_tagged
 from lobster.errors import Message_Handler
 
 list_of_compared_attributes = ['name', 'kind', 'status', 'just_down', 'just_up', 'just_global']
@@ -14,6 +13,104 @@ class QueryCodebeamerTest(unittest.TestCase):
         for obj1, obj2 in zip(list1, list2):
             for attr in list_of_compared_attributes:
                 self.assertEqual(getattr(obj1, attr), getattr(obj2, attr), f"{obj1} is not like {obj2} in {attr}")
+
+    @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')
+    def test_get_query_with_ID(self, mock_query_cb_single):
+        mh = Message_Handler()
+        mock_cb_config = {
+            "root" : "https://codebeamer.bmwgroup.net",
+            "base": "https://test.com",
+            "page_size": 10
+        }
+        mock_query = 171619121
+        item_data = [
+            {
+                "item": {
+                    "id": 34886222,
+                    "name" : "mock item",
+                    "version": 8,
+                    "tracker": {
+                        "id": 34158092
+                        },
+                    "categories": [{"name": "Requirement"}],
+                    "status": {"name": "Content Review",}
+                }
+            }
+        ]
+        mock_query_cb_single.return_value = {
+                "page": 1,
+                "pageSize": 100,
+                "total": 1,
+                "items": item_data
+            }
+
+        result = get_query(mh, mock_cb_config, mock_query)
+        self.assertEqual(len(result), 1)
+
+        self.assertEqual(result[0].kind, item_data[0]["item"]["categories"][0]["name"])
+        self.assertEqual(result[0].status, item_data[0]["item"]["status"]["name"])
+        self.assertEqual(result[0].name, item_data[0]["item"]["name"])
+        self.assertEqual(result[0].tag.tag, str(item_data[0]["item"]["id"]))
+        self.assertEqual(result[0].location.item, item_data[0]["item"]["id"])
+        self.assertEqual(result[0].location.tracker, item_data[0]["item"]["tracker"]["id"])
+        self.assertEqual(result[0].location.version, item_data[0]["item"]["version"])
+
+    @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')
+    def test_get_query_with_query(self, mock_query_cb_single):
+        mh = Message_Handler()
+        mock_cb_config = {
+            "root" : "https://codebeamer.bmwgroup.net",
+            "base": "https://test.com",
+            "page_size": 10
+        }
+        mock_query = "TeamID IN (10833708) AND workItemStatus IN ('InProgress') AND summary LIKE 'Vulnerable Road User'"
+        item_data = [
+            {
+                "id": 34886222,
+                "name" : "mock item",
+                "version": 8,
+                "tracker": {
+                    "id": 34158092
+                    },
+                "categories": [{"name": "Requirement"}],
+                "status": {"name": "Content Review",}
+            }
+        ]
+        mock_query_cb_single.return_value = {
+                "page": 1,
+                "pageSize": 100,
+                "total": 1,
+                "items": item_data
+            }
+
+        result = get_query(mh, mock_cb_config, mock_query)
+        self.assertEqual(len(result), 1)
+
+        self.assertEqual(result[0].kind, item_data[0]["categories"][0]["name"])
+        self.assertEqual(result[0].status, item_data[0]["status"]["name"])
+        self.assertEqual(result[0].name, item_data[0]["name"])
+        self.assertEqual(result[0].tag.tag, str(item_data[0]["id"]))
+        self.assertEqual(result[0].location.item, item_data[0]["id"])
+        self.assertEqual(result[0].location.tracker, item_data[0]["tracker"]["id"])
+        self.assertEqual(result[0].location.version, item_data[0]["version"])
+
+    @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')
+    def test_get_query_with_invalid_data(self, mock_query_cb_single):
+        mock_query = 789
+        mh = Message_Handler()
+        mock_cb_config = {
+            "root" : "https://codebeamer.bmwgroup.net",
+            "base": "https://test.com",
+            "page_size": 10
+        }
+        mock_query_cb_single.return_value = {
+                "page": 1,
+                "pageSize": 100,
+                "total": 1,
+                "items": []
+            }
+        with self.assertRaises(SystemExit):
+            get_query(mh, mock_cb_config, mock_query)
 
     @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')
     def test_get_single_item(self, mock_get):


### PR DESCRIPTION
GitHub Issue: #87
Query string (CBQL query) can be now passed as a parameter in config file to the lobster codebeamer tool