### PR TITLE
Write `FILE_OR_DIR` requirement

### DIFF
--- a/lobster/tools/json/software_requirements.trlc
+++ b/lobster/tools/json/software_requirements.trlc
@@ -6,8 +6,10 @@ req.Software_Requirement Synthetic_Tag_Name {
     If the command line option --name-attribute is not given, then the tool shall create
     a synthetic tag name based on the path of the JSON input file and an item counter.
 
-    Note: The item counter does not need to be unique across files.
-    It shall be unique at least for each input file separately.
+    Notes:
+    - "Synthetic" means that, the name does not need to be related to the data.
+    - The item counter does not need to be unique across files.
+      But it shall be unique at least for each input file separately.
   '''
 }
 

--- a/lobster/tools/json/system_requirements.trlc
+++ b/lobster/tools/json/system_requirements.trlc
@@ -1,0 +1,40 @@
+package json_req
+import req
+
+req.Definition JSON_Input_File {
+    description = '''
+      Each file with the file name extension json is a valid input file.
+    '''
+}
+
+req.Definition File_Scanning {
+    description = '''
+      The term "scanning an input file" means that the tool
+      1. searches for JSON elements in it according to the configuration provided by
+         the user,
+      2. and serializes these elements in LOBSTER interchange format to the desired
+         output.
+      
+      Note:
+      It is possible to write a system test to verify that the tool is scanning a file
+      in the following way:
+      1. Define a set of valid input files containing valid elements.
+      2. Run the tool.
+      3. Verify that the resulting output contains (exactly) all of the input elements.
+    '''
+}
+
+req.Definition Directory_Scanning {
+    description = '''
+    The term "scanning a directory" means that the tool scans each file inside that directory
+    according to [[File_Scanning]], if it is a JSON file according to [[JSON_Input_File]].
+    '''
+}
+
+req.System_Requirement Directory_Input {
+  description = '''
+    If a list element given through the command line option FILE_OR_DIR is a directory,
+    then that directory and recursively all subdirectories shall be scanned
+    according to [[Directory_Scanning]].
+  '''
+}

--- a/lobster/tools/requirements.rsl
+++ b/lobster/tools/requirements.rsl
@@ -3,7 +3,7 @@ package req
 type System_Requirement {
   description '''
     The content of the requirement.
-    A tool requirement describes the behaviour of a lobster tool from the point of view of the user.
+    A tool requirement describes the behavior of a lobster tool from the point of view of the user.
     It does not describe implementation details.
   ''' String
 }
@@ -11,6 +11,14 @@ type System_Requirement {
 type Software_Requirement {
   description '''
     The content of the requirement.
-    A software requirement describes the behaviour of a lobster tool.
+    A software requirement describes the behavior of a class method or module function.
+  ''' String
+}
+
+type Definition {
+  description '''
+    The text of the definition.
+    A definition shall be formulated such that it is reusable in multiple requirements,
+    to prevent the need of duplicating text.
   ''' String
 }


### PR DESCRIPTION
Write a requirement to specify the behavior of `lobster-json` if input files or directories are specified by the user.