### PR TITLE
Remove hard-coded file name `requirements.trlc` from `make tracing`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ report.lobster-%: lobster/tools/lobster.conf \
 
 requirements.lobster-%: lobster/tools/requirements.rsl
 	$(eval TOOL_PATH := $(subst -,/,$*))   
-	lobster-trlc lobster/tools/$(TOOL_PATH)/requirements.trlc lobster/tools/requirements.rsl \
+	lobster-trlc lobster/tools/$(TOOL_PATH) lobster/tools/requirements.rsl \
 	--config-file=lobster/tools/lobster-trlc.conf \
 	--out requirements.lobster
 


### PR DESCRIPTION
The build target `make tracing` now takes all `*.trlc` files into account that it finds in a LOBSTER tool folder. The file name is no longer fixed to be `requirements.trlc`.

https://github.com/bmw-software-engineering/lobster/pull/188 renamed the file to `software_requirements.trlc`, and hence the LOBSTER report for `lobster-json` could not be generated any more. This pull request fixes the `Makefile` accordingly.