### PR TITLE
Compute coverage of all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ unit-tests:
 	coverage run -p \
 			--branch --rcfile=coverage.cfg \
 			--data-file .coverage \
+			--source=lobster \
 			-m unittest discover -s tests-unit -v
 
 upload-main: packages
@@ -102,7 +103,7 @@ full-release:
 coverage:
 	coverage combine -q
 	coverage html --rcfile=coverage.cfg
-	coverage report --rcfile=coverage.cfg --fail-under=58
+	coverage report --rcfile=coverage.cfg --fail-under=53
 
 test: clean-coverage system-tests unit-tests
 	make coverage

--- a/coverage.cfg
+++ b/coverage.cfg
@@ -8,9 +8,3 @@ exclude_lines =
     def __repr__(self)
     def sanity_test()
     if __name__ == "__main__"
-
-[run]
-omit =
-    /usr/*
-    */site-packages/*
-    tests-unit/*

--- a/tests-system/run_tool_tests.py
+++ b/tests-system/run_tool_tests.py
@@ -136,14 +136,12 @@ def _run_test(setup: TestSetup, tool: str) -> CompletedProcess:
     print(f"Starting system test '{setup.name}' with arguments {setup.args} " \
           f"for tool '{tool}' with coverage.")
     root_directory = Path(__file__).resolve().parents[1]
-    coverage_config_path = root_directory / "coverage.cfg"
-    coverage_data_path = root_directory / ".coverage"
-
     coverage_command = [
         "coverage", "run", "-p",
-        f"--rcfile={coverage_config_path}",
+        f"--rcfile={root_directory / 'coverage.cfg'}",
         "--branch",
-        f"--data-file={coverage_data_path}",
+        f"--data-file={root_directory / '.coverage'}",
+        f"--source={root_directory / 'lobster'}",
         tool, *setup.args
     ]
 


### PR DESCRIPTION
Include all files from the `lobster` folder when computing the coverage.

This implies three changes:
- set `--source=lobster` when running unit tests
- set `--source=<relative path to "lobster">` when running system tests
- remove the `omit` section from the coverage computation file
- reduce the `--fail-under` parameter