### PR TITLE
cmd-config-for-lobster-tool-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 * Minor fix of handling multithreading in `lobster-json`.
 
+* Introduced YAML-based configuration for `lobster-tool-class`, replacing individual command-line arguments.
+  * Added a `--config` argument to specify a YAML configuration file.
+  * Eliminated the need for direct command-line arguments like `--out`, `--single`, `--inputs`, and `--inputs-from-file`, simplifying user interaction.
+
 * The title and placeholder for search box is renamed to `Filter` in 
   `lobster-html-report` tool.
 

--- a/packages/lobster-tool-json/README.md
+++ b/packages/lobster-tool-json/README.md
@@ -17,6 +17,39 @@ your own tool for your own files.
 
 * `lobster-json`: Extract activities from JSON files
 
+## Configuration via YAML
+
+The tool uses a YAML configuration file to define the following common parameters:
+
+  1) inputs: A list of input file paths (can include directories).
+  2) out: The name of the output file where results will be stored.
+  3) inputs-from-file: A file containing paths to input files or directories.
+  4) single: A flag to avoid the use of multiprocessing. If true, multiprocessing will be skipped.
+
+  * YAML Configuration Example:
+
+    Below is an example of how you can define these parameters in the YAML configuration file:
+
+    ```yaml
+    out: "output.lobster"  # Output file where results will be written
+    inputs:
+        - "file1.json"
+        - "file2.json"
+        - "directory1/"
+    inputs-from-file: "directory1/"  # File containing a list of input files or directories
+    single: false  # Set to true to avoid multiprocessing
+    ```
+
+  * Command-Line Usage:
+
+    To run the tool with the specified YAML configuration file, use the following command:
+
+    ```bash
+    lobster-json --config /path/to/config.yaml
+    ```
+
+    Where /path/to/config.yaml is the path to your YAML configuration file.
+
 ## Usage
 
 Some projects store their test vectors in JSON files. This tool can be
@@ -49,7 +82,7 @@ Here we have a list of three tests. You can configure the
 $ lobster-json --name-attribute "name" \
                --tag-attribute "tags" \
                --justification-attribute "justification" \
-               FILENAME
+               --config "/path/to/config.yaml"
 ```
 
 The name attribute is optional. If your test files do not contain
@@ -82,7 +115,7 @@ Then you can get to the data like so:
 $ lobster-json --name-attribute "meta.name" \
                --tag-attribute "meta.req" \
                --justification-attribute "meta.just" \
-               FILENAME
+               --config "/path/to/config.yaml"
 ```
 
 Finally, if your list of tests is nested more deeply in an object, you

--- a/tests-integration/projects/basic/Makefile
+++ b/tests-integration/projects/basic/Makefile
@@ -44,9 +44,8 @@ software-requirements.lobster: potato.rsl potato.trlc
 	@lobster-trlc *.rsl *.trlc \
 		--out="software-requirements.lobster"
 
-json.lobster: example.json
-	@lobster-json example.json \
-		--name-attribute "name" \
+json.lobster:
+	@lobster-json --name-attribute "name" \
 		--tag-attribute "tags" \
 		--justification-attribute "justification" \
-		--out="json.lobster"
+		--config="config.yaml"

--- a/tests-integration/projects/basic/config.yaml
+++ b/tests-integration/projects/basic/config.yaml
@@ -1,0 +1,3 @@
+out    : json.lobster
+inputs :
+  - example.json

--- a/tests-integration/projects/filter/Makefile
+++ b/tests-integration/projects/filter/Makefile
@@ -33,9 +33,8 @@ requirements.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
 	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
 		--out="requirements.lobster"
 
-json.lobster: test_example.json
-	@lobster-json test_example.json \
-		--name-attribute "name" \
+json.lobster:
+	@lobster-json --name-attribute "name" \
 		--tag-attribute "tags" \
 		--justification-attribute "justification" \
-		--out="json.lobster"
+		--config="config.yaml"

--- a/tests-integration/projects/filter/config.yaml
+++ b/tests-integration/projects/filter/config.yaml
@@ -1,0 +1,3 @@
+out    : json.lobster
+inputs :
+  - test_example.json

--- a/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/expected-output/stdout.txt
+++ b/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/expected-output/stdout.txt
@@ -1,2 +1,2 @@
-<cmdline>: lobster warning: not a .json file
+<config>: lobster warning: not a .json file
 lobster-json: wrote 2 items to output.lobster

--- a/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/input/args.txt
+++ b/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/input/args.txt
@@ -1,5 +1,3 @@
 --name-attribute=fruit
 --tag-attribute=vegtable
---out=output.lobster
-data.txt
-data.json
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/input/config.yaml
+++ b/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/input/config.yaml
@@ -1,0 +1,4 @@
+out    : output.lobster
+inputs :
+  - data.txt
+  - data.json

--- a/tests-system/lobster-json/rbt-input-file-json-extension/single-other-extension/expected-output/stdout.txt
+++ b/tests-system/lobster-json/rbt-input-file-json-extension/single-other-extension/expected-output/stdout.txt
@@ -1,2 +1,2 @@
-<cmdline>: lobster warning: not a .json file
+<config>: lobster warning: not a .json file
 lobster-json: wrote 1 items to output.lobster

--- a/tests-system/lobster-json/rbt-input-file-json-extension/single-other-extension/input/args.txt
+++ b/tests-system/lobster-json/rbt-input-file-json-extension/single-other-extension/input/args.txt
@@ -1,4 +1,3 @@
 --name-attribute=fruit
 --tag-attribute=vegtable
---out=output.lobster
-data.txt
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-input-file-json-extension/single-other-extension/input/config.yaml
+++ b/tests-system/lobster-json/rbt-input-file-json-extension/single-other-extension/input/config.yaml
@@ -1,0 +1,3 @@
+out    : output.lobster
+inputs :
+  - data.txt

--- a/tests-system/lobster-json/rbt-input-not-file-not-directory/nothing-exists/expected-output/stdout.txt
+++ b/tests-system/lobster-json/rbt-input-not-file-not-directory/nothing-exists/expected-output/stdout.txt
@@ -1,1 +1,1 @@
-<cmdline>: lobster error: file/does/not_exists.json is not a file or directory
+<config>: lobster error: file/does/not_exists.json is not a file or directory

--- a/tests-system/lobster-json/rbt-input-not-file-not-directory/nothing-exists/input/args.txt
+++ b/tests-system/lobster-json/rbt-input-not-file-not-directory/nothing-exists/input/args.txt
@@ -1,2 +1,2 @@
 --tag-attribute=pizza
-file/does/not_exists.json
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-input-not-file-not-directory/nothing-exists/input/config.yaml
+++ b/tests-system/lobster-json/rbt-input-not-file-not-directory/nothing-exists/input/config.yaml
@@ -1,0 +1,2 @@
+inputs :
+  - file/does/not_exists.json

--- a/tests-system/lobster-json/rbt-input-not-file-not-directory/one-file-exists/expected-output/stdout.txt
+++ b/tests-system/lobster-json/rbt-input-not-file-not-directory/one-file-exists/expected-output/stdout.txt
@@ -1,1 +1,1 @@
-<cmdline>: lobster error: file/does/not_exists.json is not a file or directory
+<config>: lobster error: file/does/not_exists.json is not a file or directory

--- a/tests-system/lobster-json/rbt-input-not-file-not-directory/one-file-exists/input/args.txt
+++ b/tests-system/lobster-json/rbt-input-not-file-not-directory/one-file-exists/input/args.txt
@@ -1,3 +1,2 @@
 --tag-attribute=soup
-file_exists.json
-file/does/not_exists.json
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-input-not-file-not-directory/one-file-exists/input/config.yaml
+++ b/tests-system/lobster-json/rbt-input-not-file-not-directory/one-file-exists/input/config.yaml
@@ -1,0 +1,3 @@
+inputs :
+  - file_exists.json
+  - file/does/not_exists.json

--- a/tests-system/lobster-json/rbt-name-attribute-missing/flat-input-structure/input/args.txt
+++ b/tests-system/lobster-json/rbt-name-attribute-missing/flat-input-structure/input/args.txt
@@ -1,3 +1,2 @@
---single
 --tag-attribute=tags
---out=output.lobster
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-name-attribute-missing/flat-input-structure/input/config.yaml
+++ b/tests-system/lobster-json/rbt-name-attribute-missing/flat-input-structure/input/config.yaml
@@ -1,0 +1,2 @@
+single : True
+out    : output.lobster

--- a/tests-system/lobster-json/rbt-name-attribute-missing/nested-input-structure/input/args.txt
+++ b/tests-system/lobster-json/rbt-name-attribute-missing/nested-input-structure/input/args.txt
@@ -1,3 +1,2 @@
---single
 --tag-attribute=tags
---out=output.lobster
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-name-attribute-missing/nested-input-structure/input/config.yaml
+++ b/tests-system/lobster-json/rbt-name-attribute-missing/nested-input-structure/input/config.yaml
@@ -1,0 +1,2 @@
+single : True
+out    : output.lobster

--- a/tests-system/lobster-json/rbt-name-attribute/attribute-given/input/args.txt
+++ b/tests-system/lobster-json/rbt-name-attribute/attribute-given/input/args.txt
@@ -1,4 +1,3 @@
---single
 --tag-attribute=tags
 --name-attribute=name
---out=output.lobster
+--config=config.yaml

--- a/tests-system/lobster-json/rbt-name-attribute/attribute-given/input/config.yaml
+++ b/tests-system/lobster-json/rbt-name-attribute/attribute-given/input/config.yaml
@@ -1,0 +1,2 @@
+single : True
+out    : output.lobster

--- a/tests-unit/test_tool.py
+++ b/tests-unit/test_tool.py
@@ -1,0 +1,68 @@
+import unittest
+import os
+import argparse
+import yaml
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from lobster.errors import Message_Handler
+
+from lobster.tool import LOBSTER_Tool
+
+class ConcreteLOSBER_Tool(LOBSTER_Tool):
+    def __init__(self, name, description, extensions, official=False):
+        super().__init__(name, description, extensions, official)
+
+    def process_tool_options(self, options, work_list):
+        return work_list
+
+    def execute(self):
+        return 0
+
+class TestLOBSTER_Tool(unittest.TestCase):
+
+    def setUp(self):
+        self.tool = ConcreteLOSBER_Tool("test", "Test description", ["lobster"], True)
+
+    def test_init(self):
+        self.assertEqual(self.tool.name, "lobster-test")
+        self.assertEqual(self.tool.description, "Test description")
+        self.assertEqual(self.tool.extensions, [".lobster"])
+        self.assertIsInstance(self.tool.mh, Message_Handler)
+
+    def test_load_yaml_config_valid_file(self):
+        with NamedTemporaryFile("w", delete=False) as temp:
+            yaml.dump({"out": "value"}, temp)
+            temp_path = temp.name
+
+        try:
+            config = self.tool.load_yaml_config(temp_path)
+            self.assertEqual(config, {"out": "value"})
+        finally:
+            os.remove(temp_path)
+
+    def test_load_yaml_config_missing_file(self):
+        with self.assertRaises(SystemExit) as context:
+            self.tool.load_yaml_config("non_existent.yaml")
+        self.assertEqual(str(context.exception), "Error: Config file 'non_existent.yaml' not found.")
+
+    def test_process_common_options_output_exits_not_file(self):
+        with TemporaryDirectory() as temp_dir:
+            options = argparse.Namespace(out=temp_dir, inputs=[], inputs_from_file=None)
+            with self.assertRaises(SystemExit):
+                self.tool.process_common_options(options)
+
+    def test_process_common_options_valid_inputs(self):
+        with TemporaryDirectory() as temp_dir:
+            with  NamedTemporaryFile("w", delete=False) as temp:
+                temp_path = temp.name
+        
+        options = argparse.Namespace(out=None, inputs=[temp_path], inputs_from_file=None)
+        work_list = self.tool.process_common_options(options)
+        self.assertEqual(work_list, [temp_path])
+
+    def test_process_common_options_invalid_inputs(self):
+        options = argparse.Namespace(out=None, inputs=["invalid.txt"], inputs_from_file=None)
+        with self.assertRaises(SystemExit):
+            self.tool.process_common_options(options)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**CMD to YAML Conversion for lobster_tool**
CMD arguments are converted to YAML for better reusability, readability, and automation. Instead of passing multiple CLI options every time, a YAML file stores them in a structured format for easy loading in scripts.