### PR TITLE
Call `close()` and `join()` on `multiprocessing.Pool()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### 0.10.1-dev
 
+* Minor fix of handling multithreading in `lobster-json`.
+
 * The title and placeholder for search box is renamed to `Filter` in 
   `lobster-html-report` tool.
 
@@ -23,7 +25,7 @@
 
 * `lobster-html-report` adds actual git commit hashes to the source in the HTML report.
 
-* `lobster-online-report` - now contains the actual git commit hashes when the user executes the tool.
+* `lobster-online-report` now contains the actual git commit hashes when the user executes the tool.
 
 * The configuration management for the following tools has been migrated from 
   command-line arguments to YAML configuration files.

--- a/lobster/tool.py
+++ b/lobster/tool.py
@@ -254,5 +254,7 @@ class LOBSTER_Per_File_Tool(LOBSTER_Tool):
                 for new_ok, new_items in pool.imap(pfun, work_list, 4):
                     ok    &= new_ok
                     items += new_items
+                pool.close()
+                pool.join()
 
         return self.write_output(ok, options, items)


### PR DESCRIPTION
According to the documentation
https://coverage.readthedocs.io/en/latest/subprocess.html#using-multiprocessing
a `pool` needs to be closed and joined, even inside a `with` block.

According to
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool
the `Pool` class calls `terminate()` whenever the context manager calls `pool.__exit()__`
This will terminate the worker processes immediately, and apparently `coverage` won't have
enough time to record its coverage measurements.

So this change is only needed to measure the coverage properly.

### Note:
Some system tests of `lobster-json` do **not** use the `--single` command line argument, like [rbt-input-file-json-extension](https://github.com/bmw-software-engineering/lobster/blob/ee2c98a303ba0fa39ece3e90206d09795004dcc0/tests-system/lobster-json/rbt-input-file-json-extension/mixed-extensions/input/args.txt).
Consequently, here we have a test that the proposed change of this pull request does not break the tool (i.e. it could hang forever if a deadlock was introduced).

At the same time we need proper coverage measurements for tests where `--single` is omitted.