### PR TITLE
Make `valid_status` constraint optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 0.10.1-dev
 
+* If the constraint `valid_status` is omitted in the configuration file of `lobster-report`,
+  then no status check is performed.
+
 * `lobster-html-report` gives consistent error message if the input file does not exist,
   even if the user specified no value. In that case the tool tries to open the file
   called `lobster.report` in the current working directory as input, and it gives the
@@ -12,7 +15,6 @@
 
 * `lobster-codebeamer` used to append `/cb` to the `root` parameter in config file 
   and now the user explicitly needs to add it while specifying the `root`.
-
 
 ### 0.10.0
 

--- a/lobster/items.py
+++ b/lobster/items.py
@@ -245,7 +245,7 @@ class Requirement(Item):
 
     def perform_source_checks(self, source_info):
         assert isinstance(source_info, dict)
-        if source_info["valid_status"]:
+        if source_info.get("valid_status"):
             if self.status not in source_info["valid_status"]:
                 self.error("status is %s, expected %s" %
                            (self.status,


### PR DESCRIPTION
If the constraint `valid_status` is omitted in the configuration file of `lobster-report`, then no check is performed.

Issue #190