### PR TITLE
Renamed Search to Filter in HTML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 0.10.1-dev
 
+* The title and placeholder for search box is renamed to `Filter` in 
+  `lobster-html-report` tool.
+
 * If the constraint `valid_status` is omitted in the configuration file of `lobster-report`,
   then no status check is performed.
 

--- a/lobster/tools/core/html_report/html_report.py
+++ b/lobster/tools/core/html_report/html_report.py
@@ -429,8 +429,8 @@ def write_html(fd, report, dot, high_contrast):
                  'onclick="ToggleIssues()"> Show Issues </button>')
     doc.add_line('</div>')
 
-    doc.add_heading(3, "Search", "search")
-    doc.add_line('<input type="text" id="search" placeholder="Search..." '
+    doc.add_heading(3, "Filter", "filter")
+    doc.add_line('<input type="text" id="search" placeholder="Filter..." '
                  'onkeyup="searchItem()">')
     doc.add_line('<div id="search-sec-id"')
 

--- a/tests-system/lobster-html-report/rbt-input-file-existance/is-file/expected-output/is_actually_html.lobster
+++ b/tests-system/lobster-html-report/rbt-input-file-existance/is-file/expected-output/is_actually_html.lobster
@@ -391,8 +391,8 @@ blockquote {
 <div id = "ContainerBtnToggleIssue">
 <button class ="button buttonBlue" id="BtnToggleIssue" onclick="ToggleIssues()"> Show Issues </button>
 </div>
-<h3 id="sec-search">Search</h3>
-<input type="text" id="search" placeholder="Search..." onkeyup="searchItem()">
+<h3 id="sec-filter">Filter</h3>
+<input type="text" id="search" placeholder="Filter..." onkeyup="searchItem()">
 <div id="search-sec-id"
 </div>
 <h2 id="sec-issues">Issues</h2>


### PR DESCRIPTION
The search box in the HTML report is renamed to Filter. Also, the placeholder for the search box is changed to filter.