### PR TITLE
Allow `--out` command line argument in lobster tool base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@
 
 * Minor fix of handling multithreading in `lobster-json`.
 
-* Introduced YAML-based configuration for `lobster-tool-class`, replacing individual command-line arguments.
+* Introduced YAML-based configuration for `lobster-json`, replacing individual command-line arguments.
   * Added a `--config` argument to specify a YAML configuration file.
-  * Eliminated the need for direct command-line arguments like `--out`, `--single`, `--inputs`, and `--inputs-from-file`, simplifying user interaction.
+  * Eliminated the need for direct command-line arguments like `--out`, `--single`, `--inputs`, and `--inputs-from-file`,
+    unifying user interaction across all lobster tools.
+  * The argument `--out` is still supported as command line argument, and takes
+    precedence over any value given in the configuration file.
 
 * The title and placeholder for search box is renamed to `Filter` in 
   `lobster-html-report` tool.

--- a/lobster/tool.py
+++ b/lobster/tool.py
@@ -123,7 +123,8 @@ class LOBSTER_Tool(metaclass=ABCMeta):
         options = self.ap.parse_args()
         config = self.load_yaml_config(options.config)
 
-        options.out = config.get("out")
+        if not options.out:
+            options.out = config.get("out")
         options.inputs_from_file = config.get("inputs_from_file")
         options.inputs = config.get("inputs", [])
         options.traverse_bazel_dirs = config.get("traverse_bazel_dirs", False)


### PR DESCRIPTION
The `out` configuration parameter shall be read from the command line first. If it has not been specified, then the class tries to fetch it from the configuration file.

The command line parameter always takes precedence over the configuration file.