### PR TITLE
Use case/traceability from cb to cpptest

### DIFF
--- a/lobster/tools/UseCase.trlc
+++ b/lobster/tools/UseCase.trlc
@@ -1,0 +1,140 @@
+package UC
+import req
+
+req.UseCase Trace_codebeamer_cpptest_1 {
+    description = '''
+    As a requirement manager I want to have a report of traceability between requirements in codebeamer and tests in C++ tests (software test).
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_2 {
+    description = '''
+    As a requirement manager I want traceability report to show the list of requirements in codebeamer which are covered by software test.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_3 {
+    description = '''
+    As a requirement manager I want traceability report to show the list of software tests covering requirements in codebeamer.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_4 {
+    description = '''
+    As a requirement manager I want traceability report to show the coverage computation between total number of requirements in codebeamer and requirements covered in software test.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_5 {
+    description = '''
+    As a requirement manager I want traceability report to show the list of requirements in codebeamer which are not covered by software test.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_6 {
+    description = '''
+    As a requirement manager I want traceability report to show the list of software test which are not covering any requirement in codebeamer.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_7 {
+    description = '''
+    As a requirement manager I want traceability report to show the tracing policy used to generate the report.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_8 {
+    description = '''
+    As a requirement manager I want traceability report to mention the codebeamer link to requirements in codebeamer.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_9 {
+    description = '''
+    As a requirement manager I want traceability report to mention the source location of the software tests.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_10 {
+    description = '''
+    As a requirement manager I want traceability report to show the data on Component level.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_11 {
+    description = '''
+    As a requirement manager I want traceability report to show the data on Service level.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_12 {
+    description = '''
+    As a requirement manager I want traceability report to show the data on Customer function level.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_13 {
+    description = '''
+    As a requirement manager I want traceability report to be generated as html file.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_14 {
+    description = '''
+    As a requirement manager I want traceability report to show the date on which report is generated.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_15 {
+    description = '''
+    As a requirement manager I want traceability report to show the mapping of requirement in codebeamer to software test covering the requirement.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_16 {
+    description = '''
+    As a requirement manager I want traceability report to show the mapping of software test to covering requirement.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_17 {
+    description = '''
+    As a requirement manager I want traceability report to show the error list.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_18 {
+    description = '''
+    As a requirement manager I want traceability report to have hyperlinks to the sections of the html report.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_19 {
+    description = '''
+    As a requirement manager I want traceability report to highlight the missing traces and good traces in different colour.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_20 {
+    description = '''
+    As a requirement manager I want traceability report to show the missing traces and good traces data in graphical form.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_21 {
+    description = '''
+    As a requirement manager I want traceability report to show the graphical representation of coverage computation.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_22 {
+    description = '''
+    As a requirement manager I want traceability report to show report overview at start of the report.
+    '''
+}
+
+req.UseCase Trace_codebeamer_cpptest_23 {
+    description = '''
+    As a requirement manager I want traceability report to be generated in English Language.
+    '''
+}

--- a/lobster/tools/UseCase.trlc
+++ b/lobster/tools/UseCase.trlc
@@ -3,138 +3,138 @@ import req
 
 req.UseCase Trace_codebeamer_cpptest_1 {
     description = '''
-    As a requirement manager I want to have a report of traceability between requirements in codebeamer and tests in C++ tests (software test).
+        As a requirement manager I want to have a report of traceability between requirements in codebeamer and tests in C++ tests (software test).
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_2 {
     description = '''
-    As a requirement manager I want traceability report to show the list of requirements in codebeamer which are covered by software test.
+        As a requirement manager I want traceability report to show the list of requirements in codebeamer which are covered by software test.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_3 {
     description = '''
-    As a requirement manager I want traceability report to show the list of software tests covering requirements in codebeamer.
+        As a requirement manager I want traceability report to show the list of software tests covering requirements in codebeamer.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_4 {
     description = '''
-    As a requirement manager I want traceability report to show the coverage computation between total number of requirements in codebeamer and requirements covered in software test.
+        As a requirement manager I want traceability report to show the coverage computation between total number of requirements in codebeamer and requirements covered in software test.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_5 {
     description = '''
-    As a requirement manager I want traceability report to show the list of requirements in codebeamer which are not covered by software test.
+        As a requirement manager I want traceability report to show the list of requirements in codebeamer which are not covered by software test.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_6 {
     description = '''
-    As a requirement manager I want traceability report to show the list of software test which are not covering any requirement in codebeamer.
+        As a requirement manager I want traceability report to show the list of software test which are not covering any requirement in codebeamer.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_7 {
     description = '''
-    As a requirement manager I want traceability report to show the tracing policy used to generate the report.
+        As a requirement manager I want traceability report to show the tracing policy used to generate the report.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_8 {
     description = '''
-    As a requirement manager I want traceability report to mention the codebeamer link to requirements in codebeamer.
+        As a requirement manager I want traceability report to mention the codebeamer link to requirements in codebeamer.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_9 {
     description = '''
-    As a requirement manager I want traceability report to mention the source location of the software tests.
+        As a requirement manager I want traceability report to mention the source location of the software tests.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_10 {
     description = '''
-    As a requirement manager I want traceability report to show the data on Component level.
+        As a requirement manager I want traceability report to show the data on Component level.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_11 {
     description = '''
-    As a requirement manager I want traceability report to show the data on Service level.
+        As a requirement manager I want traceability report to show the data on Service level.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_12 {
     description = '''
-    As a requirement manager I want traceability report to show the data on Customer function level.
+        As a requirement manager I want traceability report to show the data on Customer function level.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_13 {
     description = '''
-    As a requirement manager I want traceability report to be generated as html file.
+        As a requirement manager I want traceability report to be generated as html file.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_14 {
     description = '''
-    As a requirement manager I want traceability report to show the date on which report is generated.
+        As a requirement manager I want traceability report to show the date on which report is generated.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_15 {
     description = '''
-    As a requirement manager I want traceability report to show the mapping of requirement in codebeamer to software test covering the requirement.
+        As a requirement manager I want traceability report to show the mapping of requirement in codebeamer to software test covering the requirement.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_16 {
     description = '''
-    As a requirement manager I want traceability report to show the mapping of software test to covering requirement.
+        As a requirement manager I want traceability report to show the mapping of software test to covering requirement.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_17 {
     description = '''
-    As a requirement manager I want traceability report to show the error list.
+        As a requirement manager I want traceability report to show the error list.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_18 {
     description = '''
-    As a requirement manager I want traceability report to have hyperlinks to the sections of the html report.
+        As a requirement manager I want traceability report to have hyperlinks to the sections of the html report.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_19 {
     description = '''
-    As a requirement manager I want traceability report to highlight the missing traces and good traces in different colour.
+        As a requirement manager I want traceability report to highlight the missing traces and good traces in different colour.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_20 {
     description = '''
-    As a requirement manager I want traceability report to show the missing traces and good traces data in graphical form.
+        As a requirement manager I want traceability report to show the missing traces and good traces data in graphical form.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_21 {
     description = '''
-    As a requirement manager I want traceability report to show the graphical representation of coverage computation.
+        As a requirement manager I want traceability report to show the graphical representation of coverage computation.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_22 {
     description = '''
-    As a requirement manager I want traceability report to show report overview at start of the report.
+        As a requirement manager I want traceability report to show report overview at start of the report.
     '''
 }
 
 req.UseCase Trace_codebeamer_cpptest_23 {
     description = '''
-    As a requirement manager I want traceability report to be generated in English Language.
+        As a requirement manager I want traceability report to be generated in English Language.
     '''
 }

--- a/lobster/tools/requirements.rsl
+++ b/lobster/tools/requirements.rsl
@@ -49,3 +49,10 @@ type Definition {
     to prevent the need of duplicating text.
   ''' String
 }
+
+type UseCase {
+  description ''' 
+  The text of the UseCase.
+  The format shall be : As a < role > I want < description of the UseCase >
+  ''' String
+}

--- a/lobster/tools/requirements.rsl
+++ b/lobster/tools/requirements.rsl
@@ -52,7 +52,7 @@ type Definition {
 
 type UseCase {
   description ''' 
-  The text of the UseCase.
-  The format shall be : As a < role > I want < description of the UseCase >
+    The text of the UseCase.
+    The format shall be : As a < role > I want < description of the UseCase >
   ''' String
 }


### PR DESCRIPTION
Update for traceability report use cases related to'C++ tests' and 'Codebeamer requirements'.
- lobster/tools/requirements.rsl :
File updated with addition of 'type UseCase' for Use case writing.
- lobster/tools/UseCase.trlc :
New file added to define use cases. The use cases for traceability report
between 'C++ tests' and 'Codebeamer requirements' are added in the file.