### PR TITLE
Include `graphviz` in `requirements_dev.txt`

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+graphviz==0.20.3
 pycodestyle==2.12.0
 pylint==3.2.4
 coverage>=7.2


### PR DESCRIPTION
`graphviz` is not a mandatory package for the end-user, but it is highly recommended that all developers use it so that their HTML reports contain a tracing policy each.