### PR TITLE
fixes the CI error because of false expected output

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,20 +37,21 @@ jobs:
           python-version: "3.9"
       - name: Install dependencies
         run: |
-          sudo apt-get install -y graphviz
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
           echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
-      - name: Generate docs
-        run: |
-          make docs
-        env:
-          PYTHONPATH: "."
       - name: Building code coverage report
         run: |
+          make lobster/html/assets.py
           make system-tests unit-tests
           make coverage
           mv htmlcov docs
+      - name: Generate docs
+        run: |
+          sudo apt-get install -y graphviz
+          make docs
+        env:
+          PYTHONPATH: "."
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
fixes the error in the CI introduced with https://github.com/bmw-software-engineering/lobster/commit/20e5f2675dc6a0bfc589d4f1bbe1debe48fca22a

because of the addition of `make -B -C tests-system TOOL=lobster-html-report` in Makefile
it was now necessary to be consistent with the install of the dot utility (graphviz) in docs.yml as well in ci.yml

Actually there is also one flaw that needs to be addressed before this change achieves the intended result:
<img width="1536" alt="image" src="https://github.com/user-attachments/assets/71315404-d5fc-4195-9569-9e9775171928" />
on left side there is the linux output of the \<svg\>\</svg\> section produced by graphviz, on the right side there is the macOS version of the output. that means the generated graphical representation of the tracing policy differs and cannot be exactly reproduced on different OS


Update: 
Because of that specific reason I propose to be consistent in **NOT** installing the dot utility (graphviz) when executing system tests. So I changed the order of commands, installs in the docs.yml file. This way graphviz will be used for the purpose of generating docs but not when producing output within the execution of system tests. That means I exclude the \<svg\>\</svg\> section from testing