### PR TITLE
Remove root folder name assertion

### DIFF
--- a/tests-system/testrunner.py
+++ b/tests-system/testrunner.py
@@ -77,11 +77,7 @@ class TestRunner(ABC):
     @staticmethod
     def get_repo_root() -> Path:
         """Returns the root directory of the LOBSTER repository."""
-        root = Path(__file__).resolve().parents[1]
-        if root.name != "lobster":
-            raise RuntimeError(f"{Path(__file__).name} must be located in a child "
-                               f"directory of the repository root.")
-        return root
+        return Path(__file__).resolve().parents[1]
 
     def run_tool_test(self) -> CompletedProcess:
         """Runs the tool under test and measures the branch coverage."""


### PR DESCRIPTION
Remove the assertion from the `TestRunner` class which made sure that the root folder name is equal to `lobster`.

This assertion fails if the local repository folder has got a different name.

Issue: https://github.com/bmw-software-engineering/lobster/issues/229