### PR TITLE
First lint, then test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           make selenium-tests
   test:
     name: TestSuite
-    needs: [lint, trlc]
+    needs: [lint, lint-system-tests, trlc]
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-13, macos-14]


### PR DESCRIPTION
Update the workflow in `ci.yml` such that linting is done first, and tests are executed only if linting succeeded.

(Previously tests did not depend on `lint-system-tests`, but only on `lint`.)