### PR TITLE
Align test names with TRLC package names

### DIFF
--- a/tests-integration/projects/coverage-half/example.rsl
+++ b/tests-integration/projects/coverage-half/example.rsl
@@ -1,4 +1,4 @@
-package coverage_example
+package coverage_half
 
 type System_Requirement
 {

--- a/tests-integration/projects/coverage-half/report.reference_output
+++ b/tests-integration/projects/coverage-half/report.reference_output
@@ -8,21 +8,21 @@
       "kind": "requirements",
       "items": [
         {
-          "tag": "req sysreq_coverage_example.requirement_1a",
+          "tag": "req coverage_half.requirement_1a",
           "location": {
             "kind": "file",
             "file": "sysreq_example.trlc",
-            "line": 4,
-            "column": 37
+            "line": 3,
+            "column": 20
           },
-          "name": "sysreq_coverage_example.requirement_1a",
+          "name": "coverage_half.requirement_1a",
           "messages": [],
           "just_up": [],
           "just_down": [],
           "just_global": [],
           "ref_up": [],
           "ref_down": [
-            "req softreq_coverage_example.requirement_2a"
+            "req coverage_half.requirement_2a"
           ],
           "tracing_status": "OK",
           "framework": "TRLC",
@@ -38,20 +38,20 @@
       "kind": "requirements",
       "items": [
         {
-          "tag": "req softreq_coverage_example.requirement_2a",
+          "tag": "req coverage_half.requirement_2a",
           "location": {
             "kind": "file",
             "file": "softreq_example.trlc",
-            "line": 5,
-            "column": 39
+            "line": 3,
+            "column": 22
           },
-          "name": "softreq_coverage_example.requirement_2a",
+          "name": "coverage_half.requirement_2a",
           "messages": [],
           "just_up": [],
           "just_down": [],
           "just_global": [],
           "ref_up": [
-            "req sysreq_coverage_example.requirement_1a"
+            "req coverage_half.requirement_1a"
           ],
           "ref_down": [],
           "tracing_status": "OK",
@@ -61,14 +61,14 @@
           "status": null
         },
         {
-          "tag": "req softreq_coverage_example.requirement_2b",
+          "tag": "req coverage_half.requirement_2b",
           "location": {
             "kind": "file",
             "file": "softreq_example.trlc",
-            "line": 11,
-            "column": 39
+            "line": 9,
+            "column": 22
           },
-          "name": "softreq_coverage_example.requirement_2b",
+          "name": "coverage_half.requirement_2b",
           "messages": [
             "missing up reference"
           ],

--- a/tests-integration/projects/coverage-half/softreq_example.trlc
+++ b/tests-integration/projects/coverage-half/softreq_example.trlc
@@ -1,14 +1,12 @@
-package softreq_coverage_example
-import coverage_example
-import sysreq_coverage_example
+package coverage_half
 
-coverage_example.Software_Requirement requirement_2a
+Software_Requirement requirement_2a
 {
    text = '''Requirement 2a'''
-   derived_from = [sysreq_coverage_example.requirement_1a]
+   derived_from = [requirement_1a]
 }
 
-coverage_example.Software_Requirement requirement_2b
+Software_Requirement requirement_2b
 {
    text = '''Requirement 2b'''
 }

--- a/tests-integration/projects/coverage-half/sysreq_example.trlc
+++ b/tests-integration/projects/coverage-half/sysreq_example.trlc
@@ -1,7 +1,6 @@
-package sysreq_coverage_example
-import coverage_example
+package coverage_half
 
-coverage_example.System_Requirement requirement_1a
+System_Requirement requirement_1a
 {
    text = '''Requirement 1a'''
 }

--- a/tests-integration/projects/coverage-half/trlc-softreq.conf
+++ b/tests-integration/projects/coverage-half/trlc-softreq.conf
@@ -1,4 +1,4 @@
-coverage_example.Software_Requirement {
+coverage_half.Software_Requirement {
   description = text
   tags "req"  = derived_from
 }

--- a/tests-integration/projects/coverage-half/trlc-sysreq.conf
+++ b/tests-integration/projects/coverage-half/trlc-sysreq.conf
@@ -1,3 +1,3 @@
-coverage_example.System_Requirement {
+coverage_half.System_Requirement {
   description = text
 }

--- a/tests-integration/projects/coverage-zero/example.rsl
+++ b/tests-integration/projects/coverage-zero/example.rsl
@@ -1,4 +1,4 @@
-package coverage_example
+package coverage_zero
 
 type System_Requirement
 {

--- a/tests-integration/projects/coverage-zero/report.reference_output
+++ b/tests-integration/projects/coverage-zero/report.reference_output
@@ -8,14 +8,14 @@
       "kind": "requirements",
       "items": [
         {
-          "tag": "req sysreq_coverage_example.requirement_4a",
+          "tag": "req coverage_zero.requirement_4a",
           "location": {
             "kind": "file",
             "file": "sysreq_example.trlc",
-            "line": 4,
-            "column": 37
+            "line": 3,
+            "column": 20
           },
-          "name": "sysreq_coverage_example.requirement_4a",
+          "name": "coverage_zero.requirement_4a",
           "messages": [
             "missing reference to Software Requirements"
           ],
@@ -36,14 +36,14 @@
       "kind": "requirements",
       "items": [
         {
-          "tag": "req softreq_coverage_example.requirement_3a",
+          "tag": "req coverage_zero.requirement_3a",
           "location": {
             "kind": "file",
             "file": "softreq_example.trlc",
-            "line": 5,
-            "column": 39
+            "line": 3,
+            "column": 22
           },
-          "name": "softreq_coverage_example.requirement_3a",
+          "name": "coverage_zero.requirement_3a",
           "messages": [
             "missing up reference"
           ],
@@ -57,14 +57,14 @@
           "status": null
         },
         {
-          "tag": "req softreq_coverage_example.requirement_3b",
+          "tag": "req coverage_zero.requirement_3b",
           "location": {
             "kind": "file",
             "file": "softreq_example.trlc",
-            "line": 10,
-            "column": 39
+            "line": 8,
+            "column": 22
           },
-          "name": "softreq_coverage_example.requirement_3b",
+          "name": "coverage_zero.requirement_3b",
           "messages": [
             "missing up reference"
           ],

--- a/tests-integration/projects/coverage-zero/softreq_example.trlc
+++ b/tests-integration/projects/coverage-zero/softreq_example.trlc
@@ -1,13 +1,11 @@
-package softreq_coverage_example
-import coverage_example
-import sysreq_coverage_example
+package coverage_zero
 
-coverage_example.Software_Requirement requirement_3a
+Software_Requirement requirement_3a
 {
    text = '''Requirement 3a'''
 }
 
-coverage_example.Software_Requirement requirement_3b
+Software_Requirement requirement_3b
 {
    text = '''Requirement 3b'''
 }

--- a/tests-integration/projects/coverage-zero/sysreq_example.trlc
+++ b/tests-integration/projects/coverage-zero/sysreq_example.trlc
@@ -1,7 +1,6 @@
-package sysreq_coverage_example
-import coverage_example
+package coverage_zero
 
-coverage_example.System_Requirement requirement_4a
+System_Requirement requirement_4a
 {
    text = '''Requirement 4a'''
 }

--- a/tests-integration/projects/coverage-zero/trlc-softreq.conf
+++ b/tests-integration/projects/coverage-zero/trlc-softreq.conf
@@ -1,4 +1,4 @@
-coverage_example.Software_Requirement {
+coverage_zero.Software_Requirement {
   description = text
   tags "req"  = derived_from
 }

--- a/tests-integration/projects/coverage-zero/trlc-sysreq.conf
+++ b/tests-integration/projects/coverage-zero/trlc-sysreq.conf
@@ -1,3 +1,3 @@
-coverage_example.System_Requirement {
+coverage_zero.System_Requirement {
   description = text
 }


### PR DESCRIPTION
The integration tests use TRLC files.
The package names in these TRLC files are now aligned with the folder name that contains the integration test files.

This is a follow-up of https://github.com/bmw-software-engineering/lobster/pull/241