### PR TITLE
Fix publishment of docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
 
     runs-on: ubuntu-24.04
 
+    # The 'docs' target requires graphviz, but the system tests require that graphviz is NOT installed
+    # So the order is important: 1.) coverage 2.) install graphviz 3.) docs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,20 +39,23 @@ jobs:
           python-version: "3.9"
       - name: Install dependencies
         run: |
-          sudo apt-get install -y graphviz
           python -m pip install --upgrade pip
-          pip install -r requirements_dev.txt
+          python -m pip install -r requirements_dev.txt
+          make lobster/html/assets.py
+      - name: Building code coverage report
+        run: |
+          make system-tests unit-tests
+          make coverage
+          mv htmlcov docs
+      - name: Install graphviz
+        run: |
+          sudo apt-get install -y graphviz
           echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
       - name: Generate docs
         run: |
           make docs
         env:
           PYTHONPATH: "."
-      - name: Building code coverage report
-        run: |
-          make system-tests unit-tests
-          make coverage
-          mv htmlcov docs
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,12 @@ test-all: integration-tests system-tests unit-tests
 	util/check_local_modifications.sh
 
 docs:
-	rm -rf docs
 	mkdir -p docs
 	@-make tracing
 	@-make tracing-stf
+
+clean-docs:
+	rm -rf docs
 
 tracing:
 	@mkdir -p docs


### PR DESCRIPTION
On the one hand it is necessary to run the system and unit tests in order to create the branch coverage report. The system tests require that graphviz is NOT installed, otherwise they fail.

On the other hand, the LOBSTER reports shall show the visualization of the tracing policy, so graphviz must be available for their generation.

The `docs.yml` workflow creates all reports and publishes them to GitHub pages. Hence the order of steps matters:
1. generate the branch coverage reports
2. install graphviz
3. generate the LOBSTER traceability reports