### PR TITLE
Use Lobster_Tool in LOBSTER_Trlc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 0.11.1-dev
 
+* `lobster-trlc` - All command-line arguments except  `--config` and `--out` are 
+  moved to Yaml based config file. `--config` and `--out` command-line arguments are still supported.
+
 * `lobster-json` - All command-line arguments except  `--config` and `--out` are 
   moved to Yaml based config file. `--config` and `--out` command-line arguments are still supported.
 

--- a/lobster/tool.py
+++ b/lobster/tool.py
@@ -145,12 +145,14 @@ class LOBSTER_Tool(SupportedCommonConfigKeys, metaclass=ABCMeta):
         -------
         Nothing
         """
-        with open(config, "r", encoding="UTF-8") as fd:
-            for line_no, line in enumerate(fd, 1):
-                if (':' in line and (line.split(':')[0]).strip() not in
-                        self.get_config_keys_as_set()):
-                    self.mh.error(File_Reference(line, line_no),
-                                  "Invalid yaml config parameter")
+        if config:
+            supported_keys = self.get_config_keys_as_set()
+            unsupported_keys = set(config.keys()) - supported_keys
+            if unsupported_keys:
+                raise KeyError(
+                    f"Unsupported config keys: {', '.join(unsupported_keys)}. "
+                    f"Supported keys are: {', '.join(supported_keys)}."
+                )
 
     def check_mandatory_config_parameters(self, config):
         """
@@ -176,10 +178,10 @@ class LOBSTER_Tool(SupportedCommonConfigKeys, metaclass=ABCMeta):
         """Processes all command line options"""
 
         options = self.ap.parse_args()
-        self.validate_yaml_supported_config_parameters(options.config)
         self.config = self.load_yaml_config(options.config)
+        self.validate_yaml_supported_config_parameters(self.config)
         self.check_mandatory_config_parameters(self.config)
-        options.inputs_from_file = self.config.get(self.INPUTS_FROM_FILE)
+        options.inputs_from_file = self.config.get(self.INPUTS_FROM_FILE, None)
         options.inputs = self.config.get(self.INPUTS, [])
         options.traverse_bazel_dirs = self.config.get(self.TRAVERSE_BAZEL_DIRS, False)
         work_list = self.process_common_options(options)

--- a/lobster/tool.py
+++ b/lobster/tool.py
@@ -163,10 +163,11 @@ class LOBSTER_Tool(SupportedCommonConfigKeys, metaclass=ABCMeta):
         -------
         Nothing
         """
-        mandatory_parameters = self.get_mandatory_parameters() - set(config.keys())
-        if mandatory_parameters:
-            sys.exit(f"Required mandatory parameters missing - "
-                     f"{','.join(mandatory_parameters)}")
+        if self.get_mandatory_parameters():
+            mandatory_parameters = self.get_mandatory_parameters() - set(config.keys())
+            if mandatory_parameters:
+                sys.exit(f"Required mandatory parameters missing - "
+                         f"{','.join(mandatory_parameters)}")
 
     @get_version
     def process_commandline_and_yaml_options(

--- a/lobster/tool.py
+++ b/lobster/tool.py
@@ -103,7 +103,7 @@ class LOBSTER_Tool(SupportedCommonConfigKeys, metaclass=ABCMeta):
 
         self.ap.add_argument(
             "--out",
-            default = None,
+            default = f'{self.name}.lobster',
             help    = "Write output to the given file instead of stdout."
         )
         self.ap.add_argument(

--- a/packages/lobster-tool-trlc/README.md
+++ b/packages/lobster-tool-trlc/README.md
@@ -96,6 +96,39 @@ attach this justification on the actual offending object.
 Finally the "global" justification is a catch all: it just means no
 tracing policy will be validated at all when considering this object.
 
+## Executing lobster-trlc tool
+
+`lobster-trlc` takes two command line arguments as follows:
+* `--config` - Yaml based config files to the parameters
+  * `trlc_config_file`: trlc configuration file as mentioned in the configuration 
+    section
+  * `inputs`: A list of input file paths (can include directories).
+  * `inputs_from_file`: A file containing paths to input files or directories.
+  * `traverse_bazel_dirs`:  Enter bazel-* directories, which are excluded by default.
+   
+* `out`: The name of the output file where results will be stored.
+
+### Command
+
+lobster-trlc --config "path to the yaml config file" --out "output file path"
+
+### Example
+
+#### trlc_config.conf
+```yaml
+req.Requirement {
+  description = description
+}
+```
+
+#### trlc_config_file.yaml
+```yaml
+inputs: [list of paths to *.trlc and *. rsl files separated by commas]
+trlc_config_file: "path to the above mentioned trlc_config.conf file"
+```
+#### In this case the command will be
+`lobster-trlc --config=trlc_config_file.yaml --out=trlc.lobster`
+
 ## Tools
 
 * `lobster-trlc`: Extrat requirements from TRLC.

--- a/packages/lobster-tool-trlc/README.md
+++ b/packages/lobster-tool-trlc/README.md
@@ -99,9 +99,10 @@ tracing policy will be validated at all when considering this object.
 ## Executing lobster-trlc tool
 
 `lobster-trlc` takes two command line arguments as follows:
-* `--config` - Yaml based config files to the parameters
+* `--config` - Yaml based config file path in which the following parameters can be 
+  mentioned.
   * `trlc_config_file`: trlc configuration file as mentioned in the configuration 
-    section
+    section and also in the example mentioned below see (trlc_config.conf)
   * `inputs`: A list of input file paths (can include directories).
   * `inputs_from_file`: A file containing paths to input files or directories.
   * `traverse_bazel_dirs`:  Enter bazel-* directories, which are excluded by default.

--- a/tests-integration/projects/basic/Makefile
+++ b/tests-integration/projects/basic/Makefile
@@ -40,9 +40,8 @@ pycode.lobster: nor.py
 		--out="pycode.lobster" \
 		--parse-decorator trlc_reference requirement
 
-software-requirements.lobster: potato.rsl potato.trlc
-	@lobster-trlc *.rsl *.trlc \
-		--out="software-requirements.lobster"
+software-requirements.lobster:
+	@lobster-trlc --config="trlc_config.yaml" --out="software-requirements.lobster"
 
 json.lobster:
 	@lobster-json --config="config.yaml" \

--- a/tests-integration/projects/basic/trlc_config.yaml
+++ b/tests-integration/projects/basic/trlc_config.yaml
@@ -1,0 +1,3 @@
+inputs :
+  - potato.rsl
+  - potato.trlc

--- a/tests-integration/projects/coverage-half/Makefile
+++ b/tests-integration/projects/coverage-half/Makefile
@@ -16,10 +16,10 @@ html_report.html: softreq.lobster sysreq.lobster lobster.conf trlc-softreq.conf 
         exit 1; \
 	fi
 
-softreq.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
-		--out="softreq.lobster" --config-file="trlc-softreq.conf"
+softreq.lobster:
+	@lobster-trlc --config="soft_req_trlc_config.yaml" \
+		--out="softreq.lobster"
 
-sysreq.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
-		--out="sysreq.lobster" --config-file="trlc-sysreq.conf"
+sysreq.lobster:
+	@lobster-trlc --config="sys_req_trlc_config.yaml" \
+		--out="sysreq.lobster"

--- a/tests-integration/projects/coverage-half/soft_req_trlc_config.yaml
+++ b/tests-integration/projects/coverage-half/soft_req_trlc_config.yaml
@@ -1,0 +1,6 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc
+
+trlc_config_file : "trlc-softreq.conf"

--- a/tests-integration/projects/coverage-half/sys_req_trlc_config.yaml
+++ b/tests-integration/projects/coverage-half/sys_req_trlc_config.yaml
@@ -1,0 +1,6 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc
+
+trlc_config_file : "trlc-sysreq.conf"

--- a/tests-integration/projects/coverage-mix/Makefile
+++ b/tests-integration/projects/coverage-mix/Makefile
@@ -16,14 +16,14 @@ html_report.html: req_a.lobster req_b.lobster test_a.lobster lobster.conf trlc_r
         exit 1; \
 	fi
 
-req_a.lobster: example.rsl req_a.trlc req_b.trlc test_spec.trlc
-	@lobster-trlc example.rsl req_a.trlc req_b.trlc test_spec.trlc\
-		--out="req_a.lobster" --config-file="trlc_req_a.conf"
+req_a.lobster:
+	@lobster-trlc --config="trlc_req_a.yaml" \
+		--out="req_a.lobster"
 
-req_b.lobster: example.rsl req_a.trlc req_b.trlc test_spec.trlc
-	@lobster-trlc example.rsl req_a.trlc req_b.trlc test_spec.trlc\
-		--out="req_b.lobster" --config-file="trlc_req_b.conf"
+req_b.lobster:
+	@lobster-trlc --config="trlc_req_b.yaml" \
+		--out="req_b.lobster"
 
-test_a.lobster: example.rsl req_a.trlc req_b.trlc test_spec.trlc
-	@lobster-trlc example.rsl req_a.trlc req_b.trlc test_spec.trlc\
-		--out="test_a.lobster" --config-file="trlc_test_spec.conf"
+test_a.lobster:
+	@lobster-trlc --config="trlc_test_spec.yaml" \
+		--out="test_a.lobster"

--- a/tests-integration/projects/coverage-mix/trlc_req_a.yaml
+++ b/tests-integration/projects/coverage-mix/trlc_req_a.yaml
@@ -1,0 +1,7 @@
+inputs :
+  - example.rsl
+  - req_a.trlc
+  - req_b.trlc
+  - test_spec.trlc
+
+trlc_config_file : "trlc_req_a.conf"

--- a/tests-integration/projects/coverage-mix/trlc_req_b.yaml
+++ b/tests-integration/projects/coverage-mix/trlc_req_b.yaml
@@ -1,0 +1,7 @@
+inputs :
+  - example.rsl
+  - req_a.trlc
+  - req_b.trlc
+  - test_spec.trlc
+
+trlc_config_file : "trlc_req_b.conf"

--- a/tests-integration/projects/coverage-mix/trlc_test_spec.yaml
+++ b/tests-integration/projects/coverage-mix/trlc_test_spec.yaml
@@ -1,0 +1,7 @@
+inputs :
+  - example.rsl
+  - req_a.trlc
+  - req_b.trlc
+  - test_spec.trlc
+
+trlc_config_file : "trlc_test_spec.conf"

--- a/tests-integration/projects/coverage-zero/Makefile
+++ b/tests-integration/projects/coverage-zero/Makefile
@@ -16,10 +16,10 @@ html_report.html: softreq.lobster sysreq.lobster lobster.conf trlc-softreq.conf 
         exit 1; \
 	fi
 
-softreq.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
-		--out="softreq.lobster" --config-file="trlc-softreq.conf"
+softreq.lobster:
+	@lobster-trlc --config="soft_req_trlc_config.yaml" \
+		--out="softreq.lobster"
 
-sysreq.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
-		--out="sysreq.lobster" --config-file="trlc-sysreq.conf"
+sysreq.lobster:
+	@lobster-trlc --config="sys_req_trlc_config.yaml" \
+		--out="sysreq.lobster"

--- a/tests-integration/projects/coverage-zero/soft_req_trlc_config.yaml
+++ b/tests-integration/projects/coverage-zero/soft_req_trlc_config.yaml
@@ -1,0 +1,6 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc
+
+trlc_config_file : "trlc-softreq.conf"

--- a/tests-integration/projects/coverage-zero/sys_req_trlc_config.yaml
+++ b/tests-integration/projects/coverage-zero/sys_req_trlc_config.yaml
@@ -1,0 +1,6 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc
+
+trlc_config_file : "trlc-sysreq.conf"

--- a/tests-integration/projects/coverage/Makefile
+++ b/tests-integration/projects/coverage/Makefile
@@ -16,10 +16,10 @@ html_report.html: softreq.lobster sysreq.lobster lobster.conf trlc-softreq.conf 
         exit 1; \
 	fi
 
-softreq.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
-		--out="softreq.lobster" --config-file="trlc-softreq.conf"
+softreq.lobster:
+	@lobster-trlc --config="soft_req_trlc_config.yaml" \
+		--out="softreq.lobster"
 
-sysreq.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
-		--out="sysreq.lobster" --config-file="trlc-sysreq.conf"
+sysreq.lobster:
+	@lobster-trlc --config="sys_req_trlc_config.yaml" \
+		--out="sysreq.lobster"

--- a/tests-integration/projects/coverage/soft_req_trlc_config.yaml
+++ b/tests-integration/projects/coverage/soft_req_trlc_config.yaml
@@ -1,0 +1,6 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc
+
+trlc_config_file : "trlc-softreq.conf"

--- a/tests-integration/projects/coverage/sys_req_trlc_config.yaml
+++ b/tests-integration/projects/coverage/sys_req_trlc_config.yaml
@@ -1,0 +1,6 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc
+
+trlc_config_file : "trlc-sysreq.conf"

--- a/tests-integration/projects/filter/Makefile
+++ b/tests-integration/projects/filter/Makefile
@@ -29,8 +29,8 @@ cppcode.lobster: foo.h foo.cpp
 	@lobster-cpp foo.cpp foo.h \
 		--out="cppcode.lobster" --clang-tidy $(CLANG_TIDY)
 
-requirements.lobster: example.rsl softreq_example.trlc sysreq_example.trlc
-	@lobster-trlc example.rsl softreq_example.trlc sysreq_example.trlc\
+requirements.lobster:
+	@lobster-trlc --config="trlc_config.yaml" \
 		--out="requirements.lobster"
 
 json.lobster:

--- a/tests-integration/projects/filter/trlc_config.yaml
+++ b/tests-integration/projects/filter/trlc_config.yaml
@@ -1,0 +1,4 @@
+inputs :
+  - example.rsl
+  - softreq_example.trlc
+  - sysreq_example.trlc

--- a/tests-system/lobster-trlc/rbt-output-file/default-scenario/expected-output/stdout.txt
+++ b/tests-system/lobster-trlc/rbt-output-file/default-scenario/expected-output/stdout.txt
@@ -1,1 +1,1 @@
-lobster-trlc: successfully wrote 1 items to trlc.lobster
+lobster-trlc: successfully wrote 1 items to lobster-trlc.lobster

--- a/tests-system/lobster-trlc/rbt-output-file/default-scenario/input/args.txt
+++ b/tests-system/lobster-trlc/rbt-output-file/default-scenario/input/args.txt
@@ -1,1 +1,1 @@
---config-file=default_file.conf
+--config=trlc_config.yaml

--- a/tests-system/lobster-trlc/rbt-output-file/default-scenario/input/trlc_config.yaml
+++ b/tests-system/lobster-trlc/rbt-output-file/default-scenario/input/trlc_config.yaml
@@ -1,0 +1,1 @@
+trlc_config_file: "default_file.conf"

--- a/tests-unit/test_json.py
+++ b/tests-unit/test_json.py
@@ -39,8 +39,8 @@ class Test_Json(unittest.TestCase):
 
     def test_invalid_json_parameters(self):
         with NamedTemporaryFile("w", delete=False) as temp:
-            config = {"invalid_key": "This is a invalid key "
-                                      "which not supported by LOBSTER Json"}
+            config = {"invalid_key": "This is an invalid key "
+                                      "which is not supported by LOBSTER Json"}
         lobster_json = LOBSTER_Json()
 
         with self.assertRaises(KeyError):

--- a/tests-unit/test_json.py
+++ b/tests-unit/test_json.py
@@ -39,13 +39,12 @@ class Test_Json(unittest.TestCase):
 
     def test_invalid_json_parameters(self):
         with NamedTemporaryFile("w", delete=False) as temp:
-            yaml.dump({"invalid_key": "This is a invalid key "
-                                      "which not supported by LOBSTER Json"}, temp)
-            temp_path = temp.name
+            config = {"invalid_key": "This is a invalid key "
+                                      "which not supported by LOBSTER Json"}
         lobster_json = LOBSTER_Json()
 
-        with self.assertRaises(LOBSTER_Error):
-            lobster_json.validate_yaml_supported_config_parameters(temp_path)
+        with self.assertRaises(KeyError):
+            lobster_json.validate_yaml_supported_config_parameters(config)
 
     def test_mandatory_json_parameters(self):
         config = {"single": True, "name_attribute": "fruit"}


### PR DESCRIPTION
Implemented LOBSTER_Tool class for LOBSTER TRLC and modified CHANGELOG, Readme, small bug fix in mandatory parameters validation.
With this implementation the lobster TRLC will start using YAML config for command line tools except  for "--out" & "--config" parameters.