### PR TITLE
Disable CI for `*.md` files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: LOBSTER CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches: ["main"]
     paths-ignore:
       - "**/*.md"
+    types:
+      - ready_for_review
+      - synchronize
+      - reopened
 
 permissions:
   contents: read


### PR DESCRIPTION
Disable the `ci.yml` GitHub action if only `*.md` files are modified. No checks are necessary then.

Also disable the action for draft pull requests.