### PR TITLE
Inputs and inputs from file duplicate content scenario test case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,8 @@ name: LOBSTER CI
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - "**/*.md"
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "**/*.md"
-    types:
-      - ready_for_review
-      - synchronize
-      - reopened
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: LOBSTER CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
+    types:
+      - ready_for_review
+      - synchronize
+      - reopened
 
 permissions:
   contents: read

--- a/lobster/tools/trlc/input_files.trlc
+++ b/lobster/tools/trlc/input_files.trlc
@@ -50,6 +50,14 @@ req.System_Requirement Input_list_Of_File_And_Inputs_From_File {
     '''
 }
 
+req.System_Requirement_Aspect Duplicate_Content_Input_list_Of_File_And_Inputs_From_File
+{
+    description = '''
+      IF both the config options [[Input_List_Of_Files]] AND [[Inputs_From_File]] has duplicate definitions,
+      THEN "duplicate_definition" error must be produced.
+    '''
+}
+
 req.System_Requirement_Aspect No_Inputs_And_No_Inputs_From_File {
     description = '''
       OTHERWISE, IF both the config options [[Input_List_Of_Files]] AND [[Inputs_From_File]] are not provided,

--- a/lobster/tools/trlc/input_files.trlc
+++ b/lobster/tools/trlc/input_files.trlc
@@ -50,7 +50,7 @@ req.System_Requirement Input_list_Of_File_And_Inputs_From_File {
     '''
 }
 
-req.System_Requirement_Aspect Duplicate_Content_Input_list_Of_File_And_Inputs_From_File
+req.System_Requirement_Aspect Duplicate_Input_list_Of_File_And_Inputs_From_File
 {
     description = '''
       IF both the config options [[Input_List_Of_Files]] AND [[Inputs_From_File]] has duplicate definitions,

--- a/tests-system/lobster-trlc/data/input_from_files_and_inputs_duplicate_contents.txt
+++ b/tests-system/lobster-trlc/data/input_from_files_and_inputs_duplicate_contents.txt
@@ -1,0 +1,2 @@
+default_file_copy.rsl
+default_file_copy.trlc

--- a/tests-system/lobster-trlc/test_input_invalid_extensions.py
+++ b/tests-system/lobster-trlc/test_input_invalid_extensions.py
@@ -10,6 +10,7 @@ class TrlcInvalidExtensionsTest(LobsterTrlcSystemTestCaseBase):
                                                    "lobster-trlc.conf")
 
     def test_invalid_extensions_inputs_files_list(self):
+        # lobster-trace: trlc_req.Invalid_Inputs_List_Of_Files_Extensions
         self._test_runner.declare_input_file(self._data_directory /
                                              "rsl_invalid_extension.slr")
         self._test_runner.declare_input_file(self._data_directory /
@@ -30,6 +31,7 @@ class TrlcInvalidExtensionsTest(LobsterTrlcSystemTestCaseBase):
         asserter.assertExitCode(1)
 
     def test_invalid_extensions_input_from_file(self):
+        # lobster-trace: trlc_req.Invalid_Inputs_From_File_Extensions
         self._test_runner.declare_inputs_from_file(self._data_directory /
                                                    "invalid_ext_inputs_from_file.txt",
                                                    self._data_directory)

--- a/tests-system/lobster-trlc/test_input_list_of_files.py
+++ b/tests-system/lobster-trlc/test_input_list_of_files.py
@@ -12,6 +12,7 @@ class InputListOfFilesTest(LobsterTrlcSystemTestCaseBase):
                                                    "lobster-trlc.conf")
 
     def test_input_files_list(self):
+        # lobster-trace: trlc_req.Input_List_Of_Files
         OUT_FILE = "input_files_list.lobster"
         self._test_runner.cmd_args.out = OUT_FILE
         self._test_runner.declare_output_file(self._data_directory / OUT_FILE)
@@ -24,6 +25,7 @@ class InputListOfFilesTest(LobsterTrlcSystemTestCaseBase):
         asserter.assertOutputFiles()
 
     def test_duplicate_input_files_list(self):
+        # lobster-trace: trlc_req.Duplicate_Input_List_Of_Files
         self._test_runner.declare_input_file(self._data_directory /
                                              "default_file_copy.rsl")
         self._test_runner.declare_input_file(self._data_directory /

--- a/tests-system/lobster-trlc/test_inputs_and_inputs_from_file.py
+++ b/tests-system/lobster-trlc/test_inputs_and_inputs_from_file.py
@@ -27,9 +27,8 @@ class InputFromFilesAndInputsTest(LobsterTrlcSystemTestCaseBase):
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
 
-
     def test_duplicate_contents_input_from_files_and_inputs_list(self):
-        # lobster-trace: trlc_req.Duplicate_Content_Input_list_Of_File_And_Inputs_From_File
+        # lobster-trace: trlc_req.Duplicate_Input_list_Of_File_And_Inputs_From_File
         self._test_runner.declare_inputs_from_file(
             self._data_directory / "input_from_files_and_inputs_duplicate_contents.txt",
             self._data_directory)

--- a/tests-system/lobster-trlc/test_inputs_and_inputs_from_file.py
+++ b/tests-system/lobster-trlc/test_inputs_and_inputs_from_file.py
@@ -26,3 +26,22 @@ class InputFromFilesAndInputsTest(LobsterTrlcSystemTestCaseBase):
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+    def test_duplicate_contents_input_from_files_and_inputs_list(self):
+        # lobster-trace: trlc_req.Duplicate_Content_Input_list_Of_File_And_Inputs_From_File
+        self._test_runner.declare_inputs_from_file(
+            self._data_directory / "input_from_files_and_inputs_duplicate_contents.txt",
+            self._data_directory)
+        completed_process = self._test_runner.run_tool_test()
+        asserter = Asserter(self, completed_process, self._test_runner)
+        asserter.assertNoStdErrText()
+        asserter.assertStdOutText('package test_default\n        ^^^^^^^^^^^^'
+                                  ' default_file_copy.rsl:1: error:'
+                                  ' duplicate definition, previous definition at'
+                                  ' default_file.rsl:1\nnamaste goodname {\n'
+                                  '        ^^^^^^^^ default_file_copy.trlc:3: error:'
+                                  ' duplicate definition, previous definition at'
+                                  ' default_file.trlc:3\nlobster-trlc: aborting due'
+                                  ' to earlier error\n')
+        asserter.assertExitCode(1)

--- a/tests-system/lobster-trlc/test_inputs_from_file.py
+++ b/tests-system/lobster-trlc/test_inputs_from_file.py
@@ -10,6 +10,7 @@ class InputFromFilesTest(LobsterTrlcSystemTestCaseBase):
                                                    "lobster-trlc.conf")
 
     def test_input_from_files(self):
+        # lobster-trace: trlc_req.Inputs_From_File
         OUT_FILE = "input_from_files.lobster"
         self._test_runner.cmd_args.out = OUT_FILE
         self._test_runner.declare_output_file(self._data_directory / OUT_FILE)
@@ -25,6 +26,7 @@ class InputFromFilesTest(LobsterTrlcSystemTestCaseBase):
         asserter.assertOutputFiles()
 
     def test_input_from_files_duplicate_contents(self):
+        # lobster-trace: trlc_req.Duplicate_Inputs_From_File
         self._test_runner.declare_inputs_from_file(self._data_directory /
                                                    "input_from_file_duplicate_data.txt",
                                                    self._data_directory)


### PR DESCRIPTION
This PR contains the following:

- Added a scenario for "File is given once in “inputs_from_file” and same file is given in “inputs”, check that “duplicate_definition” error is produced"
- Added lobster traces for lobster-trlc system test cases.