### PR TITLE
Fix CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     paths-ignore:
       - "**/*.md"
     types:
+      - opened
       - ready_for_review
       - synchronize
       - reopened
@@ -18,8 +19,54 @@ permissions:
   contents: read
 
 jobs:
+  # Job to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      py_modified: ${{ steps.changed-py-files.outputs.any_modified }}
+      trlc_modified: ${{ steps.changed-trlc-files.outputs.any_modified }}
+      only_docu_modified: ${{ steps.changed-docu-files.outputs.only_modified }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: changed-py-files
+      uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 #v46.0.3
+      with:
+        output_renamed_files_as_deleted_and_added: true
+        files: |
+          *.py
+          **/*.py
+          *.cfg
+          **/*.cfg
+    - id: changed-docu-files
+      uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 #v46.0.3
+      with:
+        output_renamed_files_as_deleted_and_added: true
+        files: |
+          *.md
+          **/*.md
+          .github/CODEOWNERS
+          documentation/**
+    - id: changed-trlc-files
+      uses: tj-actions/changed-files@823fcebdb31bb35fdf2229d9f769b400309430d0 #v46.0.3
+      with:
+        output_renamed_files_as_deleted_and_added: true
+        files: |
+          *.rsl
+          **/*.rsl
+          *.trlc
+          **/*.trlc
+    - name: Debug output
+      run: |
+        echo "py any_modified: ${{ steps.changed-py-files.outputs.any_modified }}"
+        echo "trlc any_modified: ${{ steps.changed-trlc-files.outputs.any_modified }}"
+        echo "docu only_modified: ${{ steps.changed-docu-files.outputs.only_modified }}"
+
   lint:
     name: PyLint
+    needs: changes
+    if: ${{ needs.changes.outputs.py_modified == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +80,8 @@ jobs:
           make lint
   lint-system-tests:
     name: PyLint System Tests
+    needs: changes
+    if: ${{ needs.changes.outputs.py_modified == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +94,8 @@ jobs:
           make lint-system-tests
   trlc:
     name: TRLC
+    needs: changes
+    if: ${{ needs.changes.outputs.trlc_modified == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +108,8 @@ jobs:
           make trlc
   selenium-tests:
     name: Run Selenium Tests
-    needs: [lint, lint-system-tests, trlc]
+    needs: [changes, lint, lint-system-tests, trlc]
+    if: ${{ always() && needs.changes.outputs.only_docu_modified == 'false' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +122,8 @@ jobs:
           make selenium-tests
   test:
     name: TestSuite
-    needs: [lint, lint-system-tests, trlc]
+    needs: [changes, lint, lint-system-tests, trlc]
+    if: ${{ always() && needs.changes.outputs.only_docu_modified == 'false' }}
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
@@ -108,7 +161,8 @@ jobs:
           make coverage
   integration-tests:
     name: Integration tests
-    needs: test
+    needs: [changes, lint, lint-system-tests, trlc]
+    if: ${{ always() && needs.changes.outputs.only_docu_modified == 'false' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -146,9 +200,16 @@ jobs:
           make integration-tests
   failure:
     name: Check all jobs
-    needs: integration-tests
+    needs:
+      - lint
+      - lint-system-tests
+      - trlc
+      - selenium-tests
+      - test
+      - integration-tests
     if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Failure
         run: exit 1
+


### PR DESCRIPTION
According to the GitHub documentation any check associated
with a skipped workflow will remain in a "Pending" state.
The pull request cannot be merged.

This was the situation since the merge of pull request https://github.com/bmw-software-engineering/lobster/pull/249:
if the commits contain only `*.md` files, then the `ci.yml`
workflow will remain pending forever, and the pull request
cannot be merged.

As a solution we can use a conditional inside the workflow
instead of the path filtering for the whole workflow.

Therefore this commit introduces the usage of action
`tj-actions/changed-files@v46.0.3`, which can give information about
files that have been added, copied, modified, renamed or deleted.

Jobs are then triggered if relevant files have been modified.

Also added the `opened` type to the list of pull request types
that shall trigger the workflow.