### PR TITLE
Remove the tool lobster-report from old STF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ integration-tests: packages
 system-tests:
 	mkdir -p docs
 	python -m unittest discover -s tests-system -v -t .
-	make -B -C tests-system TOOL=lobster-report
 	make -B -C tests-system TOOL=lobster-trlc
 	make -B -C tests-system TOOL=lobster-python
 	make -B -C tests-system TOOL=lobster-online-report


### PR DESCRIPTION
Now all tests for the tool lobster-report are been migrated to new STF hence, removed the lobster-report tool from the old STF