### PR TITLE
Precise summary message of `lobster-online-report`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### 0.12.1-dev
 
+* Reformulate the summary message of `lobster-online-report` so that it becomes
+  clear whether the input file has been modified, or whether a new output file has been
+  created.
+
 * `lobster-cpptest` now displays a test-name instead of a fixture-name
   in the lobster-report and lobster-html-report.
 

--- a/lobster/tools/core/online_report/online_report.py
+++ b/lobster/tools/core/online_report/online_report.py
@@ -233,10 +233,16 @@ def main():
                 commit=commit)
             item.location = loc
 
-    report.write_report(options.out if options.out else options.lobster_report)
-    print("LOBSTER report %s changed to use online references" %
-          options.out if options.out else options.lobster_report)
+    out_file = options.out if options.out else options.lobster_report
+    report.write_report(out_file)
+    print(get_summary(options.lobster_report, out_file))
     return 0
+
+
+def get_summary(in_file: str, out_file: str):
+    if in_file == out_file:
+        return f"LOBSTER report {in_file} modified to use online references."
+    return f"LOBSTER report {out_file} created, using online references."
 
 
 if __name__ == "__main__":

--- a/tests-system/lobster-online-report/rbt-valid-flow/valid-scenario/expected-output/stdout.txt
+++ b/tests-system/lobster-online-report/rbt-valid-flow/valid-scenario/expected-output/stdout.txt
@@ -1,1 +1,1 @@
-LOBSTER report expected-output.lobster changed to use online references
+LOBSTER report expected-output.lobster created, using online references.

--- a/tests-unit/lobster-online-report/test_online_report.py
+++ b/tests-unit/lobster-online-report/test_online_report.py
@@ -7,22 +7,21 @@ from io import StringIO
 from os.path import dirname
 from pathlib import Path
 
-from lobster.tools.core.online_report.online_report import main
+from lobster.tools.core.online_report.online_report import main, get_summary
 
 
 class LobsterOnlineReportTests(unittest.TestCase):
-    def setUp(self):
-        self.input_file = str(Path(dirname(__file__), "data",
-                                   "report-lobster.output"))
-        self.online_report = "online-report.lobster"
-
     def test_valid_inputs(self):
-        sys.argv = ["lobster-online-report", self.input_file,
-                    f'--out={self.online_report}']
+        input_file = str(Path(dirname(__file__), "data",
+                                   "report-lobster.output"))
+        online_report = "online-report.lobster"
+
+        sys.argv = ["lobster-online-report", input_file,
+                    f'--out={online_report}']
         with StringIO() as stdout, redirect_stdout(stdout):
             exit_code = main()
             output = stdout.getvalue()
-        with open(self.online_report, 'r') as file:
+        with open(online_report, 'r') as file:
             data = json.load(file)
             for level in data['levels']:
                 for item in level['items']:
@@ -31,8 +30,17 @@ class LobsterOnlineReportTests(unittest.TestCase):
                         if 'file' in location:
                             self.assertIsNotNone(location.get('commit'))
         self.assertEqual(exit_code, 0)
-        self.assertIn(f"LOBSTER report {self.online_report} "
-                      f"changed to use online references", output)
+
+    def test_print_summary_same_values(self):
+        value = "marble"
+        actual = get_summary(value, value)
+        self.assertEqual(actual, f"LOBSTER report {value} modified to use online references.")
+
+    def test_print_summary_different_values(self):
+        in_file = "basalt"
+        out_file = "granite"
+        actual = get_summary(in_file, out_file)
+        self.assertEqual(actual, f"LOBSTER report {out_file} created, using online references.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Write the summary message of `lobster-online-report` more precisely
so that it becomes clear whether the input file has been modified,
or whether a new output file has been created.