### PR TITLE
Move authentication provision into separate function

### DIFF
--- a/lobster/tools/codebeamer/bearer_auth.py
+++ b/lobster/tools/codebeamer/bearer_auth.py
@@ -1,0 +1,10 @@
+from requests.auth import AuthBase
+
+
+class BearerAuth(AuthBase):
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        r.headers['Authorization'] = f'Bearer {self.token}'
+        return r

--- a/tests-unit/lobster-codebeamer/test_authentication.py
+++ b/tests-unit/lobster-codebeamer/test_authentication.py
@@ -1,0 +1,46 @@
+import unittest
+from requests.auth import HTTPBasicAuth
+from lobster.tools.codebeamer.bearer_auth import BearerAuth
+from lobster.tools.codebeamer.codebeamer import get_authentication
+from lobster.tools.codebeamer.config import AuthenticationConfig, Config
+
+class AuthenticationTest(unittest.TestCase):
+
+    _USERS = [None, "Procyon"]
+    _PASSWORDS = [None, "Andromeda"]
+
+    def test_get_bearer_auth(self):
+        # This test verifies that the bearer authentication always takes precedence over
+        # basic authentication.
+
+        for password in self._PASSWORDS:
+            for user in self._USERS:
+                with self.subTest(user=user, password=password):
+                    cb_auth_conf=AuthenticationConfig(
+                        token="local bubble",
+                        user=None,
+                        password=None,
+                        root="milky way",
+                    )
+                    auth = get_authentication(cb_auth_conf)
+                    self.assertIsInstance(auth, BearerAuth)
+    
+    def test_get_basic_auth(self):
+        # This test verifies that the basic authentication is returned,
+        # even if the user name and/or password are missing.
+
+        for password in self._PASSWORDS:
+            for user in self._USERS:
+                with self.subTest(user=user, password=password):
+                    cb_auth_conf=AuthenticationConfig(
+                        token=None,
+                        user=user,
+                        password=password,
+                        root="orion arm",
+                    )
+                    auth = get_authentication(cb_auth_conf)
+                    self.assertIsInstance(auth, HTTPBasicAuth)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Extract the creation of the authentication data from `query_cb_single`
and move it into a separate function.

Clean up import statements.

Move class `BearerAuth` into separate file.

This change has no impact on features of `lobster-codebeamer`. It is only a refactoring.