### PR TITLE
Use data class for configuration in `codebeamer.py`

### DIFF
--- a/lobster/tools/codebeamer/config.py
+++ b/lobster/tools/codebeamer/config.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class AuthenticationConfig:
+    token: Optional[str]
+    user: Optional[str]
+    password: Optional[str]
+    root: str
+
+
+@dataclass
+class Config:
+    references: dict
+    import_tagged: str
+    import_query: str
+    verify_ssl: bool
+    page_size: int
+    schema: str
+    timeout: int
+    out: str
+    cb_auth_conf: AuthenticationConfig
+
+    @property
+    def base(self) -> str:
+        return f"{self.cb_auth_conf.root}/api/v3"

--- a/tests-unit/lobster-codebeamer/test.netrc
+++ b/tests-unit/lobster-codebeamer/test.netrc
@@ -1,0 +1,3 @@
+machine example.com
+login the-user-name
+password the-password


### PR DESCRIPTION
Introduce a data class to store the configuration parameters of `lobster-codebeamer`
to replace the dictionary. This also removes many magic strings.

Also remove unused parameter `mh` from function `get_query` and `import_tagged`.