### PR TITLE
Added fix for reports generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,17 +159,25 @@ report.lobster-%: lobster/tools/lobster.conf \
 		--out=report.lobster
 	lobster-online-report report.lobster
 
-system_requirements.lobster-%: lobster/tools/requirements.rsl
-	$(eval TOOL_PATH := $(subst -,/,$*))   
-	lobster-trlc lobster/tools/$(TOOL_PATH) lobster/tools/requirements.rsl \
-	--config-file=lobster/tools/lobster-trlc-system.conf \
-	--out system_requirements.lobster
+system_requirements.lobster-%: TRLC_CONFIG = lobster/tools/lobster-trlc-system.conf
 
-software_requirements.lobster-%: lobster/tools/requirements.rsl
-	$(eval TOOL_PATH := $(subst -,/,$*))   
-	lobster-trlc lobster/tools/$(TOOL_PATH) lobster/tools/requirements.rsl \
-	--config-file=lobster/tools/lobster-trlc-software.conf \
-	--out software_requirements.lobster
+system_requirements.lobster-%:
+	$(eval TOOL_PATH := $(subst -,/,$*))
+	@echo "inputs: ['lobster/tools/requirements.rsl', 'lobster/tools/$(TOOL_PATH)']" > lobster/tools/config.yaml
+	@echo "trlc_config_file: $(TRLC_CONFIG)" >> lobster/tools/config.yaml
+	lobster-trlc --config=lobster/tools/config.yaml \
+	--out=system_requirements.lobster
+	rm lobster/tools/config.yaml
+
+software_requirements.lobster-%: TRLC_CONFIG = lobster/tools/lobster-trlc-software.conf
+
+software_requirements.lobster-%:
+	$(eval TOOL_PATH := $(subst -,/,$*))
+	@echo "inputs: ['lobster/tools/requirements.rsl', 'lobster/tools/$(TOOL_PATH)']" > lobster/tools/config.yaml
+	@echo "trlc_config_file: $(TRLC_CONFIG)" >> lobster/tools/config.yaml
+	lobster-trlc --config=lobster/tools/config.yaml \
+	--out=software_requirements.lobster
+	rm lobster/tools/config.yaml
 
 code.lobster-%:
 	$(eval TOOL_PATH := $(subst -,/,$*))
@@ -180,7 +188,8 @@ unit-tests.lobster-%:
 	lobster-python --activity --out unit-tests.lobster tests-unit/lobster-$(TOOL_NAME)
 
 system-tests.lobster-%:
-	lobster-python --activity --out=system-tests.lobster tests-system/lobster-$*
+	$(eval TOOL_NAME := $(subst _,-,$(notdir $(TOOL_PATH))))
+	lobster-python --activity --out=system-tests.lobster tests-system/lobster-$(TOOL_NAME)
 
 # STF is short for System Test Framework
 STF_TRLC_FILES := $(wildcard tests-system/*.trlc)

--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,8 @@ STF_PYTHON_FILES := $(filter-out tests-system/test_%.py tests-system/run_tool_te
 
 # This target is used to generate the LOBSTER report for the requirements of the system test framework itself.
 tracing-stf: $(STF_TRLC_FILES)
-	lobster-trlc tests-system lobster/tools/requirements.rsl --config-file=lobster/tools/lobster-trlc-system.conf --out=stf_system_requirements.lobster
-	lobster-trlc tests-system lobster/tools/requirements.rsl --config-file=lobster/tools/lobster-trlc-software.conf --out=stf_software_requirements.lobster
+	lobster-trlc --config=lobster/tools/lobster-trlc-system-stf.yaml --out=stf_system_requirements.lobster
+	lobster-trlc --config=lobster/tools/lobster-trlc-software-stf.yaml --out=stf_software_requirements.lobster
 	lobster-python --out=stf_code.lobster --only-tagged-functions $(STF_PYTHON_FILES)
 	lobster-report --lobster-config=tests-system/stf-lobster.conf --out=stf_report.lobster
 	lobster-online-report stf_report.lobster

--- a/lobster/tools/lobster-trlc-software-stf.yaml
+++ b/lobster/tools/lobster-trlc-software-stf.yaml
@@ -1,0 +1,2 @@
+inputs: ['lobster/tools/requirements.rsl', 'tests-system/system_test_framework.trlc']
+trlc_config_file: 'lobster\tools\lobster-trlc-software.conf'

--- a/lobster/tools/lobster-trlc-system-stf.yaml
+++ b/lobster/tools/lobster-trlc-system-stf.yaml
@@ -1,0 +1,2 @@
+inputs: ['lobster/tools/requirements.rsl', 'tests-system/system_test_framework.trlc']
+trlc_config_file: 'lobster/tools/lobster-trlc-system.conf'

--- a/lobster/tools/lobster.conf
+++ b/lobster/tools/lobster.conf
@@ -4,6 +4,7 @@ requirements "System Requirements" {
 
 requirements "Software Requirements" {
   source: "software_requirements.lobster";
+  trace to: "System Requirements";
 }
 
 implementation "Code" {

--- a/lobster/tools/lobster.conf
+++ b/lobster/tools/lobster.conf
@@ -4,7 +4,6 @@ requirements "System Requirements" {
 
 requirements "Software Requirements" {
   source: "software_requirements.lobster";
-  trace to: "System Requirements";
 }
 
 implementation "Code" {


### PR DESCRIPTION
lobster-trlc tool was modified to use Yaml configuration but the `tracing` target which is used to generate the `lobster-html-reports` for all the LOBSTER tools was not updated. Due to this issue the reports were not generated.
Also the tracing policy was modified and `Software Requirements` trace to `System Requirements` was removed.