### PR TITLE
Feature: lobster-cpptest has test-name in tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### 0.12.1-dev
 
-* Add command line argument `--skip-clang-errors` to `lobster-cpp`.
+* `lobster-cpptest` now displays a test-name instead of a fixture-name
+  in the lobster-report and lobster-html-report.* Add command line argument `--skip-clang-errors` to `lobster-cpp`.
   This argument allows the user to specify a list of `clang-tidy`
   errors which shall be skipped.
 

--- a/lobster/tools/cpptest/cpptest.py
+++ b/lobster/tools/cpptest/cpptest.py
@@ -240,7 +240,7 @@ def create_lobster_items_output_dict_from_test_cases(
         lobster_items_output_dict[no_marker_output_file_name] = {}
 
     for test_case in test_case_list:
-        function_name: str = test_case.suite_name
+        function_name: str = test_case.test_name
         file_name = os.path.abspath(test_case.file_name)
         line_nr = int(test_case.docu_start_line)
         function_uid = "%s:%s:%u" % (os.path.basename(file_name),

--- a/packages/lobster-tool-cpptest/README.md
+++ b/packages/lobster-tool-cpptest/README.md
@@ -75,6 +75,11 @@ You can also include CPP files in the YAML configuration file.
 ```
 Note: File paths are accepted only in single quotes.
 
+## Technical Aspects
+
+`lobster-cpptest` now displays a test-name instead of a fixture-name 
+in the lobster-report and lobster-html-report.
+
 ## Copyright & License information
 
 The copyright holder of LOBSTER is the Bayerische Motoren Werke

--- a/tests-unit/lobster-cpptest/test_cpptest.py
+++ b/tests-unit/lobster-cpptest/test_cpptest.py
@@ -335,9 +335,9 @@ class LobsterCpptestTests(unittest.TestCase):
 
         # just check a few refs from the written unit test lobster items
         expected_unit_test_refs_dicts = {
-            "cpp test_case.cpp:RequirementByTest1:130":
+            "cpp test_case.cpp:RequiredByWithAt:130":
                 ["req FOO0::BAR0", "req FOO1::BAR1"],
-            "cpp test_case.cpp:RequirementByTest1:135":
+            "cpp test_case.cpp:RequiredByWithAt:135":
                 ["req FOO0::BAR0", "req FOO1::BAR1", "req FOO2::BAR2", "req FOO3::BAR3", "req FOO4::BAR4",
                  "req FOO5::BAR5", "req FOO6::BAR6", "req FOO7::BAR7", "req FOO8::BAR8"]
         }
@@ -366,9 +366,9 @@ class LobsterCpptestTests(unittest.TestCase):
 
         # just check a few refs from the written component test lobster items
         expected_component_test_refs_dicts = {
-            "cpp test_case.cpp:RequirementTagTest1:70":
+            "cpp test_case.cpp:RequirementAsOneLineComments:70":
                 ["req 0815", "req 0816"],
-            "cpp test_case.cpp:RequirementTagTest1:75":
+            "cpp test_case.cpp:RequirementAsComments:75":
                 ["req 0815", "req 0816", "req 0817", "req 0818", "req 0819", "req 0820"]
         }
 


### PR DESCRIPTION
Earlier lobster-cpptest showed the fixture-name in tag in the HTML report.
This feature implementation will now show test-name instead of fixture name in the tag.