### PR TITLE
Ensure to run `ci.yml` regardless of the file type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: LOBSTER CI
 on:
   push:
     branches: ["main"]
-    paths-ignore:
-      - "**/*.md"
   pull_request:
     branches: ["main"]
-    paths-ignore:
-      - "**/*.md"
     types:
       - opened
       - ready_for_review


### PR DESCRIPTION
The `ci.yml` has already been updated to use `tj-actions/changed-files` to run jobs based on file extensions.
But the `paths-ignore` flag had not been removed, so the workflow would not run if only `*.md` files were modified.

Hence `paths-ignore` has now been removed.