### PR TITLE
use file path to generate UID in `lobster-cpp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ### 0.12.1-dev
 
+* `lobster-cpp` uses the relative file path of a c++ file to generate
+  the unique identifier of a function in that file. This way files with identical
+  names (but in different folders) are supported, and they can even have
+  C++ functions with identical names without running into a
+  "duplicate definition" problem.
+  Previously only the file's base name was used.
+
 * Reformulate the summary message of `lobster-online-report` so that it becomes
   clear whether the input file has been modified, or whether a new output file has been
   created.


### PR DESCRIPTION
`lobster-cpp` uses the file path of a function's file to generate
the unique identifier for that function.
Previously it only used the basename of the file.