### PR TITLE
System tests specify custom temp directory path

### DIFF
--- a/tests-system/system_test_case_base.py
+++ b/tests-system/system_test_case_base.py
@@ -10,10 +10,10 @@ class SystemTestCaseBase(TestCase):
         self.maxDiff = None  # pylint: disable=invalid-name
         self._temp_dirs: List[TemporaryDirectory] = []
 
-    def create_temp_dir(self, prefix: str) -> Path:
+    def create_temp_dir(self, prefix: str, dir_path: str = None) -> Path:
         # lobster-trace: system_test.Create_Temporary_Directory
         # pylint: disable=consider-using-with
-        temp_dir = TemporaryDirectory(prefix=prefix)
+        temp_dir = TemporaryDirectory(prefix=prefix, dir=dir_path)
         self._temp_dirs.append(temp_dir)
         return Path(temp_dir.name)
 


### PR DESCRIPTION
Added an option to specify path for the temporary directory for system tests