### PR TITLE
More precisely CB url in documentation

### DIFF
--- a/documentation/manual-lobster_cpptest.md
+++ b/documentation/manual-lobster_cpptest.md
@@ -87,7 +87,7 @@ In addition, you have to provide the `codebeamer-url`:
                 "kind": "imp"
             }
 	},
-	"codebeamer_url": "https://codebeamer.example.com/test"
+	"codebeamer_url": "https://codebeamer.example.com/cb"
 }
  ```
 


### PR DESCRIPTION
Replace the exemplary URL `https://codebeamer.example.com/cb` with `https://codebeamer.example.com/test` because users were confused whether they have to add "cb" at the end of the URL. Standard codebeamer installations use "cb" at the end.