### PR TITLE
Optimize calls to git in lobster-online-report

### DIFF
--- a/lobster/tools/core/online_report/online_report.py
+++ b/lobster/tools/core/online_report/online_report.py
@@ -142,6 +142,62 @@ def parse_git_root(cfg):
     return gh_root
 
 
+def add_github_reference_to_items(gh_root, gh_submodule_roots, repo_root, report):
+    """Function to add GitHub reference to items of the report"""
+    git_hash_cache = {}
+    for item in report.items.values():
+        if isinstance(item.location, File_Reference):
+            assert (os.path.isdir(item.location.filename) or
+                    os.path.isfile(item.location.filename))
+
+            git_hash_key = (gh_root, tuple(gh_submodule_roots), item.location.filename)
+            if git_hash_key not in git_hash_cache:
+                actual_path, actual_repo, commit = get_git_commit_hash_repo_and_path(
+                    gh_root, gh_submodule_roots, item, repo_root)
+                git_hash_cache[git_hash_key] = (actual_path, actual_repo, commit)
+            else:
+                actual_path, actual_repo, commit = git_hash_cache[git_hash_key]
+
+            loc = Github_Reference(
+                gh_root=actual_repo,
+                filename=actual_path,
+                line=item.location.line,
+                commit=commit)
+            item.location = loc
+
+
+def get_git_commit_hash_repo_and_path(gh_root, gh_submodule_roots, item, repo_root):
+    """Function to get git commit hash for the item file which is part of either the
+    root repo or the submodules."""
+    rel_path_from_root = os.path.relpath(item.location.filename,
+                                         repo_root)
+    # pylint: disable=possibly-used-before-assignment
+    actual_repo = gh_root
+    actual_path = rel_path_from_root
+    commit = get_hash_for_git_commit(repo_root)
+    # pylint: disable=consider-using-dict-items
+    for prefix in gh_submodule_roots:
+        if path_starts_with_subpath(rel_path_from_root, prefix):
+            actual_repo = gh_submodule_roots[prefix]
+            actual_path = rel_path_from_root[len(prefix) + 1:]
+            commit = get_hash_for_git_commit(prefix)
+            commit = commit.strip()
+            break
+    return actual_path, actual_repo, commit
+
+
+def get_hash_for_git_commit(repo_root):
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo_root
+    ).decode().strip()
+
+
+def get_summary(in_file: str, out_file: str):
+    if in_file == out_file:
+        return f"LOBSTER report {in_file} modified to use online references."
+    return f"LOBSTER report {out_file} created, using online references."
+
+
 ap = argparse.ArgumentParser()
 
 
@@ -209,55 +265,6 @@ def main():
     report.write_report(out_file)
     print(get_summary(options.lobster_report, out_file))
     return 0
-
-
-def add_github_reference_to_items(gh_root, gh_submodule_roots, repo_root, report):
-    """Function to add GitHub reference to items of the report"""
-    for item in report.items.values():
-        if isinstance(item.location, File_Reference):
-            assert (os.path.isdir(item.location.filename) or
-                    os.path.isfile(item.location.filename))
-
-            actual_path, actual_repo, commit = get_git_commit_hash_repo_and_path(
-                gh_root, gh_submodule_roots, item, repo_root)
-            loc = Github_Reference(
-                gh_root=actual_repo,
-                filename=actual_path,
-                line=item.location.line,
-                commit=commit)
-            item.location = loc
-
-
-def get_git_commit_hash_repo_and_path(gh_root, gh_submodule_roots, item, repo_root):
-    """Function to get git commit hash for the item file which is part of either the
-    root repo or the submodules."""
-    rel_path_from_root = os.path.relpath(item.location.filename,
-                                         repo_root)
-    # pylint: disable=possibly-used-before-assignment
-    actual_repo = gh_root
-    actual_path = rel_path_from_root
-    commit = get_hash_for_git_commit(repo_root)
-    # pylint: disable=consider-using-dict-items
-    for prefix in gh_submodule_roots:
-        if path_starts_with_subpath(rel_path_from_root, prefix):
-            actual_repo = gh_submodule_roots[prefix]
-            actual_path = rel_path_from_root[len(prefix) + 1:]
-            commit = get_hash_for_git_commit(prefix)
-            commit = commit.strip()
-            break
-    return actual_path, actual_repo, commit
-
-
-def get_hash_for_git_commit(repo_root):
-    return subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=repo_root
-    ).decode().strip()
-
-
-def get_summary(in_file: str, out_file: str):
-    if in_file == out_file:
-        return f"LOBSTER report {in_file} modified to use online references."
-    return f"LOBSTER report {out_file} created, using online references."
 
 
 if __name__ == "__main__":

--- a/tests-unit/lobster-online-report/test_online_report.py
+++ b/tests-unit/lobster-online-report/test_online_report.py
@@ -51,6 +51,7 @@ class LobsterOnlineReportTests(unittest.TestCase):
         root = " https://github.com/bmw-software-engineering/lobster"
         submodule_roots = {}
         repo_root = pathlib.Path().cwd()
+        git_hash_cache = {}
         location = File_Reference("/data/basic.py")
         tag = Tracing_Tag("test_namespace", "python basic.trlc_reference")
         item = Item(tag, location)
@@ -59,7 +60,7 @@ class LobsterOnlineReportTests(unittest.TestCase):
             universal_newlines=True, cwd=repo_root
         ).strip()
         actual_path, actual_repo, commit = get_git_commit_hash_repo_and_path(
-            root, submodule_roots, item, repo_root)
+            root, submodule_roots, item, repo_root, git_hash_cache)
         self.assertEqual(expected_commit, commit)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Optimized the calls to git to fetch the hashes if there are duplicate git root or git submodule root for multiple files