### PR TITLE
Fix URL generation in `Codebeamer_Reference` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 
 ### 0.12.2-dev
 
-
+* `lobster-html-report`:
+  - Fix bug where `/cb` appeared twice in codebeamer URLs, leading to an incorrect URL.
+  - Fix bug where codebeamer URLs always pointed to the HEAD version of the codebeamer item,
+    even if a specific version was given.
 
 ### 0.12.1
 

--- a/lobster/location.py
+++ b/lobster/location.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # LOBSTER - Lightweight Open BMW Software Traceability Evidence Report
-# Copyright (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (C) 2023, 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -18,9 +18,8 @@
 # <https://www.gnu.org/licenses/>.
 
 from abc import ABCMeta, abstractmethod
-
 import html
-
+from typing import Optional
 from lobster.exceptions import LOBSTER_Exception
 
 
@@ -208,7 +207,8 @@ class Github_Reference(Location):
 
 
 class Codebeamer_Reference(Location):
-    def __init__(self, cb_root, tracker, item, version, name=None):
+    def __init__(self, cb_root: str, tracker: int, item: int,
+                 version: Optional[int] = None, name: Optional[str] = None):
         assert isinstance(cb_root, str)
         assert cb_root.startswith("http")
         assert isinstance(tracker, int) and tracker >= 1
@@ -227,22 +227,18 @@ class Codebeamer_Reference(Location):
         return (self.cb_root, self.tracker, self.item)
 
     def to_string(self):
+        # lobster-trace: Codebeamer_Item_as_String
         if self.name:
             return "cb item %u '%s'" % (self.item, self.name)
         else:
             return "cb item %u" % self.item
 
     def to_html(self):
+        # lobster-trace: Codebeamer_URL
         url = self.cb_root
-        # This is supposed to open the document view, but it doesn't
-        # always work.
-        #
-        # url += "/cb/tracker/%u" % self.tracker
-        # url += "?view_id=-11&selectedItemId=%u" % self.item
-        # url += "&forceDocumentViewLayout=true"
-
-        # We can just open the item directly
-        url += "/cb/issue/%u" % self.item
+        url += "/issue/%u" % self.item
+        if self.version:
+            url += "?version=%u" % self.version
         return '<a href="%s" target="_blank">%s</a>' % (url, self.to_string())
 
     def to_json(self):

--- a/lobster/tools/core/html_report/requirements.trlc
+++ b/lobster/tools/core/html_report/requirements.trlc
@@ -1,16 +1,48 @@
 package core_html_report_req
 import req
 
-req.Software_Requirement Dummy_Requirement {
+req.System_Requirement Clickable_Codebeamer_Item {
   description = '''
-    This is not really a requirement. It will be used only to generate a minimal tracing report for each tool.
-    It can be deleted as soon as all the tools get their real requirements.
+    If the input LOBSTER report file contains codebeamer items
+    THEN the generated HTML report
+    SHALL represent these as hyperlinks to the item on the codebeamer server,
+    where the codebeamer server URL is taken from the repo_root configuration parameter.
   '''
 }
 
-req.Software_Requirement Dummy_Requirement_Unit_Test {
+req.Software_Requirement Codebeamer_URL {
   description = '''
-    This is not really a requirement. It will be used only to generate a minimal tracing report for each tool.
-    It can be deleted as soon as all the tools get their real requirements.
+    The "to_html" method of the Codebeamer_Reference class
+    SHALL return a string representation of an HTML anchor element
+    to the codebeamer item by constructing the URL as follows:
+    
+    "<repo_roo>/issue/<item_id><version_addon>"
+    
+    where  <repo_root> is taken from the configuration file,
+    and <item_id> is the codebeamer item ID taken from the LOBSTER input file,
+    and <version_addon> is "?version=<version>"
+    IF the version number of the codebeamer item is given,
+    OTHERWISE <version_addon> is an empty string.
+  '''
+  derived_from = [Clickable_Codebeamer_Item]
+}
+
+req.System_Requirement Codebeamer_Item_Name {
+  description = '''
+    If the input LOBSTER report file contains codebeamer items
+    THEN the generated HTML report
+    SHALL represent these by their codebeamer item name, if it is given.
   '''
 }
+
+req.Software_Requirement Codebeamer_Item_as_String {
+    description = '''
+      The "to_string" method of the Codebeamer_Reference class
+      SHALL return the following string:
+      
+      "cb item <ITEM_ID> '<NAME>'"
+
+      where <ITEM_ID> is the codebeamer item ID
+      and <NAME> the codebeamer item name given to the class constructor.
+      '''
+    }

--- a/tests-unit/test_location.py
+++ b/tests-unit/test_location.py
@@ -1,0 +1,47 @@
+import sys
+from unittest import TestCase
+from lobster.location import Codebeamer_Reference
+
+class CodebeamerReferenceTests(TestCase):
+    _CB_ROOT = "http://turtle:123456789"
+
+    def test_codebeamer_reference_to_html(self):
+        for name in (None, "pelican"):
+            for version in (None, 44):
+                with self.subTest(name=name, version=version):
+                    cb_ref = Codebeamer_Reference(
+                        cb_root=self._CB_ROOT,
+                        tracker=42,
+                        item=43,
+                        version=version,
+                        name=name,
+                    )
+                    version_addon = f"?version={version}" if version else ""
+                    expected_html = f'<a href="{self._CB_ROOT}/issue/{cb_ref.item}{version_addon}" target="_blank">{cb_ref.to_string()}</a>'
+                    self.assertEqual(expected_html, cb_ref.to_html())
+
+    def test_codebeamer_reference_to_string(self):
+        for name in (None, "duck"):
+            for item in (1, 45, sys.maxsize):
+                with self.subTest(name=name, item=item):
+                    cb_ref = Codebeamer_Reference(
+                        cb_root=self._CB_ROOT,
+                        tracker=44,
+                        item=item,
+                        version=46,
+                        name=name,
+                    )
+                    expected_string = f"cb item {cb_ref.item}"
+                    if name:
+                        expected_string += f" '{name}'"
+                    self.assertEqual(expected_string, cb_ref.to_string())
+
+    def test_codebeamer_reference_sorting_key(self):
+        cb_ref = Codebeamer_Reference(
+            cb_root=self._CB_ROOT,
+            tracker=47,
+            item=48,
+        )
+        expected_key = (self._CB_ROOT, cb_ref.tracker, cb_ref.item)
+        self.assertEqual(expected_key, cb_ref.sorting_key())
+


### PR DESCRIPTION
The `to_html` method appended an additional `/cb` to the root url,
leading to an incorrect url.
It also appends `?version=<version>` if a version is given.

Add type hints to the class constructor method.

Add unit tests.

The bug has been introduced with https://github.com/bmw-software-engineering/lobster/pull/201