### PR TITLE
Support identical C++ test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ### 0.12.2-dev
 
+* `lobster-cpptest`
+  - Add support for identical test case files in different folders:
+    If test cases exist in different files with the same file names, same test case names
+    and same line numbers, then previously these were treated as duplicate definitions
+    by `lobster-report`.
+    Now `lobster-cpptest` generates a unique ID by appending a counter to the file base
+    name, which is used as tag in the final report.
+    An alternative had been to use the absolute or relative path of the file instead of
+    just the file base name, but that would have decreased the readability of the report.
+
 * `lobster-html-report`:
   - Fix bug where `/cb` appeared twice in codebeamer URLs, leading to an incorrect URL.
   - Fix bug where codebeamer URLs always pointed to the HEAD version of the codebeamer item,

--- a/lobster/tools/cpptest/cpptest.py
+++ b/lobster/tools/cpptest/cpptest.py
@@ -27,6 +27,7 @@ from lobster.exceptions import LOBSTER_Exception
 from lobster.items import Tracing_Tag, Activity
 from lobster.location import File_Reference
 from lobster.io import lobster_write
+from lobster.tools.cpptest.file_tag_generator import FileTagGenerator
 from lobster.tools.cpptest.parser.constants import Constants
 from lobster.tools.cpptest.parser.requirements_parser import \
     ParserForRequirements
@@ -234,11 +235,12 @@ def create_lobster_items_output_dict_from_test_cases(
         if isinstance(marker_list, list) and len(marker_list) >= 1:
             marker_output_config_dict[output_file_name] = output_config_dict
 
+    file_tag_generator = FileTagGenerator()
     for test_case in test_case_list:
         function_name: str = test_case.test_name
         file_name = os.path.abspath(test_case.file_name)
         line_nr = int(test_case.docu_start_line)
-        function_uid = "%s:%s:%u" % (os.path.basename(file_name),
+        function_uid = "%s:%s:%u" % (file_tag_generator.get_tag(file_name),
                                      function_name,
                                      line_nr)
         tag = Tracing_Tag(NAMESPACE_CPP, function_uid)

--- a/lobster/tools/cpptest/file_tag_generator.py
+++ b/lobster/tools/cpptest/file_tag_generator.py
@@ -1,0 +1,16 @@
+from collections import defaultdict
+import os.path
+
+
+class FileTagGenerator:
+    def __init__(self):
+        self._basenames_to_lookup = defaultdict(dict)
+
+    def get_tag(self, file_name: str) -> str:
+        """Generates a unique tag for the given file based on its basename.
+           The tag is in the format 'basename:index', where index is the
+           number of times the basename has been encountered so far.
+        """
+        basename = os.path.basename(file_name)
+        lookup = self._basenames_to_lookup[basename]
+        return lookup.setdefault(file_name, f"{basename}:{len(lookup) + 1}")

--- a/tests-unit/lobster-cpptest/test_file_tag_generator.py
+++ b/tests-unit/lobster-cpptest/test_file_tag_generator.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from lobster.tools.cpptest.file_tag_generator import FileTagGenerator
+
+
+class FileTagGeneratorTest(TestCase):
+    def setUp(self):
+        self.generator = FileTagGenerator()
+
+    def test_unique_tags(self):
+        basename = "file.txt"
+        tag1 = self.generator.get_tag(f"/path/to/{basename}")
+        tag2 = self.generator.get_tag(f"/another/path/to/{basename}")
+        self.assertEqual(tag1, f"{basename}:1")
+        self.assertEqual(tag2, f"{basename}:2")
+
+    def test_same_file_same_tag(self):
+        path = "/path/to/file.abc"
+        tag1 = self.generator.get_tag(path)
+        tag2 = self.generator.get_tag(path)
+        self.assertEqual(tag1, tag2)
+
+    def test_basename_only(self):
+        file = "document.abc"
+        tag1 = self.generator.get_tag(file)
+        self.assertEqual(tag1, f"{file}:1")


### PR DESCRIPTION
If test cases exist in different files with the same file names, same test case names
and same line numbers, then previously these were treated as duplicate definitions
by `lobster-report`.
Now `lobster-cpptest` generates a unique ID by appending a counter to the file base
name, which is used as tag in the final report.
An alternative had been to use the absolute or relative path of the file instead of
just the file base name, but that would have decreased the readability of the report.