### PR TITLE
separate-coverage-for-unit_test-and-system_test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,8 @@ jobs:
           make system-tests
       - name: Coverage analysis
         run: |
-          make coverage
+          make coverage-system
+          make coverage-unit
   integration-tests:
     name: Integration tests
     needs: [changes, lint, lint-system-tests, trlc]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Building code coverage report
         run: |
           make system-tests unit-tests
-          make coverage
+          make coverage-system
+          make coverage-unit
           mv htmlcov docs
       - name: Install graphviz
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 0.12.2
 
+* `Separate Coverage Reports`
+  - Separate coverage reports for unit tests (`.coverage.unit`) and system tests (`.coverage.system`).
+
 * `lobster-online-report`
   - Fix for git hash generation for submodules when the tool is executed from 
     outside a git repository where the submodule is specified as a relative path.

--- a/tests-system/test_runner.py
+++ b/tests-system/test_runner.py
@@ -89,7 +89,7 @@ class TestRunner(ABC):
             "run",
             "-p",
             f"--rcfile={root_directory / 'coverage.cfg'}",
-            f"--data-file={root_directory / '.coverage'}",
+            f"--data-file={root_directory / '.coverage.system'}",
             f"--source={root_directory / 'lobster'}",
             "--branch",
             self._tool_main_path,


### PR DESCRIPTION
Split test coverage into separate reports for **unit** and **system** tests using `coverage.py`, enabling focused tool qualification based on system test results.
