### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@
 
 ### 0.12.3-dev
 
-
-
-### 0.12.2
-
 * `Separate Coverage Reports`
   - Separate coverage reports for unit tests (`.coverage.unit`) and system tests (`.coverage.system`).
+
+### 0.12.2
 
 * `lobster-online-report`
   - Fix for git hash generation for submodules when the tool is executed from 


### PR DESCRIPTION
Version 0.12.2 has already been released, so any new implementations must be documented under section "0.12.3-dev".