### PR TITLE
Use 0% coverage in case of zero items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 ### 0.12.3-dev
 
+* `lobster-report`
+  - If there are zero items in one level of the tracing policy, then this level now
+    shows a coverage of 0%.
+    Previously its coverage was 100%.
+    Note that the coverage ratio cannot be computed in a mathematical way if there
+    are zero items, because the formula requires to divide by the total number of items.
+    If this denominator is zero, obviously the division cannot be performed.
+    So neither 100% nor 0% makes sense, but choosing 0% is the safe decision
+    when the tool is used in a safety-critical context.
+    Having zero input items is probably not what the user intended to do,
+    and shall be notified about this empty input.
+    The user has a greater chance to detect this empty input if the report shows 0% coverage
+    compared to 100%, which indicates that everything is okay.
+
 * `lobster-cpp`
   * The file basename is used to construct the function UID.
     A counter is then appended to the basename to handle situations where files in

--- a/lobster/report.py
+++ b/lobster/report.py
@@ -102,12 +102,10 @@ class Report:
 
     def compute_coverage_for_items(self):
         for level_obj in self.coverage.values():
-            if level_obj.ok == level_obj.items:
-                level_obj.coverage = 100.0
+            if level_obj.items == 0:
+                level_obj.coverage = 0.0
             else:
-                level_obj.coverage = (
-                    float(level_obj.ok * 100) / float(level_obj.items)
-                )
+                level_obj.coverage = float(level_obj.ok * 100) / float(level_obj.items)
 
     def compute_item_count_and_status(self):
         for level in self.config:

--- a/tests-unit/lobster-report/test_report.py
+++ b/tests-unit/lobster-report/test_report.py
@@ -1,4 +1,43 @@
-# please consider writing here your tests and set your tracing tags. 
-# This file will be used in the tracing report
-# if any other file or files are used, make the needed
-# adjsutments to tracing report target.
+from unittest import TestCase
+from lobster.report import Coverage, Report
+
+
+class ReportTests(TestCase):
+    def test_compute_coverage(self):
+        report = Report()
+        level_name = "Calculus Master Mind"
+
+        MAX_SUPPORTED_ITEMS = 100000000
+
+        for num_items in list(range(0, 10000)) + [MAX_SUPPORTED_ITEMS / 2, MAX_SUPPORTED_ITEMS]:
+            for ok_items in set((0, 1, 2, int(num_items / 2), max(num_items - 1, 0), num_items)):
+                if num_items < ok_items:
+                    continue
+
+                report.coverage[level_name] = Coverage(
+                    level=level_name,
+                    items=num_items,
+                    ok=ok_items,
+                    coverage=None
+                )
+                report.compute_coverage_for_items()
+                if num_items == 0:
+                    self.assertEqual(report.coverage[level_name].coverage, 0.0)
+                else:
+                    expected_coverage = (float(ok_items * 100) / float(num_items))
+                    if ok_items != num_items:
+                        self.assertNotEqual(
+                            expected_coverage,
+                            100.0,
+                            f"Invalid test setup: The expected coverage for {num_items}"
+                            f" items with {ok_items} ok items should not be exactly "
+                            f"100.0! This is a floating point problem, and not "
+                            f"necessarily a bug.",
+                        )
+                    self.assertEqual(
+                        report.coverage[level_name].coverage,
+                        expected_coverage,
+                        f"Expected coverage for {num_items} items with {ok_items} ok "
+                        f"items to be {expected_coverage}, but got "
+                        f"{report.coverage[level_name].coverage}",
+                    )


### PR DESCRIPTION
Set the coverage value to 0% if there are zero items in the tracing policy level.

Add unit test.