### PR TITLE
New Tool `lobster-online-report-nogit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ### 0.12.3-dev
 
+* `lobster-online-report-nogit`
+
+  This new tool is similar to `lobster-online-report`, but does not
+  call the `git` tool to obtain information about the repository.
+  Instead it relies solely on information provided by the user through
+  command line arguments.
+
 * `lobster-report`
   - If there are zero items in one level of the tracing policy, then this level now
     shows a coverage of 0%.
@@ -20,11 +27,11 @@
     compared to 100%, which indicates that everything is okay.
 
 * `lobster-cpp`
-  * The file basename is used to construct the function UID.
+  - The file basename is used to construct the function UID.
     A counter is then appended to the basename to handle situations where files in
     different folders have the same basename.
     Now `lobster-cpp` and `lobster-cpptest` use the same logic to generate function UIDs.
-  * The `*.lobster` output file uses the absolute path for location entries instead of a
+  - The `*.lobster` output file uses the absolute path for location entries instead of a
     relative path.
     This simplifies the usage of the LOBSTER tools, for instance in a CI system, where
     different tools are called from different working directories.

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,23 @@ packages:
 	diff -Naur test_install/lib/python*/site-packages/lobster test_install_monolithic/lib/python*/site-packages/lobster -x "*.pyc"
 	diff -Naur test_install/bin test_install_monolithic/bin
 
+	# Very basic smoke tests to ensure the core tools are available
+	test_install_monolithic/bin/lobster-report --version
+	test_install_monolithic/bin/lobster-ci-report --version
+	test_install_monolithic/bin/lobster-html-report --version
+	test_install_monolithic/bin/lobster-online-report --version
+	test_install_monolithic/bin/lobster-online-report-nogit --version
+
+	# Very basic smoke tests to ensure the other tools are available
+	test_install_monolithic/bin/lobster-cpp --version
+	test_install_monolithic/bin/lobster-cpptest --version
+	test_install_monolithic/bin/lobster-codebeamer --version
+	test_install_monolithic/bin/lobster-gtest --version
+	test_install_monolithic/bin/lobster-json --version
+	test_install_monolithic/bin/lobster-python --version
+	test_install_monolithic/bin/lobster-trlc --version
+
+
 clang-tidy:
 	cd .. && \
 	git clone https://github.com/bmw-software-engineering/llvm-project && \

--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ The following verification and miscellaneous frameworks are supported:
 
 The individual PyPI packages that `bmw-lobster` depends on are:
 
-* `bmw-lobster-core` the core API and various report generators. All
-  other tools depend on this [Link](https://pypi.org/project/bmw-lobster-core)
+* `bmw-lobster-core` the core API and various report generators.
+  All other tools depend on this.
+  The package also contains core tools.
+  See the package description for more details.
+  [Link](https://pypi.org/project/bmw-lobster-core)
 * `bmw-lobster-tool-codebeamer` (for requirements in Codebeamer) [Link](https://pypi.org/project/bmw-lobster-tool-codebeamer)
 * `bmw-lobster-tool-cpp` (for C/C++ code) [Link](https://pypi.org/project/bmw-lobster-tool-cpp)
 * `bmw-lobster-tool-cpptest` (for C/C++ code) [Link](https://pypi.org/project/bmw-lobster-tool-cpp)
@@ -118,6 +121,7 @@ Here are the links to the individual requirement coverage reports:
 * [Requirement Coverage Report Core CI Report](https://bmw-software-engineering.github.io/lobster/tracing-core_ci_report.html)
 * [Requirement Coverage Report Core HTML Report](https://bmw-software-engineering.github.io/lobster/tracing-core_html_report.html)
 * [Requirement Coverage Report Core Online Report](https://bmw-software-engineering.github.io/lobster/tracing-core_online_report.html)
+* Requirement Coverge Report Core Online Report Nogit: not yet available
 * [Requirement Coverage Report Core Report](https://bmw-software-engineering.github.io/lobster/tracing-core_report.html)
 * [Requirement Coverage Report Codebeamer](https://bmw-software-engineering.github.io/lobster/tracing-codebeamer.html)
 

--- a/lobster-online-report-nogit
+++ b/lobster-online-report-nogit
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# LOBSTER - Lightweight Open BMW Software Traceability Evidence Report
+# Copyright (C) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with this program. If not, see
+# <https://www.gnu.org/licenses/>.
+
+import sys
+from lobster.tools.core.online_report_nogit.online_report_nogit import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lobster/location.py
+++ b/lobster/location.py
@@ -19,25 +19,25 @@
 
 from abc import ABCMeta, abstractmethod
 import html
-from typing import Optional
+from typing import Any, Dict, Optional, Tuple
 from lobster.exceptions import LOBSTER_Exception
 
 
 class Location(metaclass=ABCMeta):
     @abstractmethod
-    def sorting_key(self):
+    def sorting_key(self) -> Tuple:
         pass
 
     @abstractmethod
-    def to_string(self):
+    def to_string(self) -> str:
         pass
 
     @abstractmethod
-    def to_html(self):
+    def to_html(self) -> str:
         pass
 
     @abstractmethod
-    def to_json(self):
+    def to_json(self) -> Dict[str, Any]:
         pass
 
     @classmethod

--- a/lobster/report.py
+++ b/lobster/report.py
@@ -187,7 +187,9 @@ class Report:
         """
         self.config = data["policy"]
         for level in data["levels"]:
-            assert level["name"] in self.config
+            assert level["name"] in self.config, (
+                f"level '{level['name']}' not found in config"
+            )
             coverage = Coverage(
                 level=level["name"], items=0, ok=0, coverage=level["coverage"]
             )
@@ -203,7 +205,9 @@ class Report:
                                                     item_data,
                                                     3)
                 else:
-                    assert level["kind"] == "activity"
+                    assert level["kind"] == "activity", (
+                        f"unknown level kind '{level['kind']}'"
+                    )
                     item = Activity.from_json(level["name"],
                                               item_data,
                                               3)

--- a/lobster/tools/core/online_report_nogit/online_report_nogit.py
+++ b/lobster/tools/core/online_report_nogit/online_report_nogit.py
@@ -1,0 +1,103 @@
+import argparse
+import os.path
+from dataclasses import dataclass
+from typing import Iterable
+from lobster.items import Item
+from lobster.location import File_Reference, Github_Reference
+from lobster.report import Report
+from lobster.version import get_version
+
+
+@dataclass
+class RepoData:
+    """
+    Data class to hold repository information.
+
+    Attributes:
+        remote_url (str): The root URL of the GitHub repository.
+        repo_root (str): The local path to the root of the repository.
+        commit (str): The commit hash to use when building a URL to a file.
+    """
+    remote_url: str
+    root: str
+    commit: str
+
+
+def file_ref_to_remote_ref(file_ref: File_Reference, repo_data: RepoData) -> (
+        Github_Reference):
+    """
+    Convert a File_Reference to a Github_Reference.
+
+    Args:
+        file_ref (File_Reference): The file reference to convert.
+        repo_data (RepoData): The repository meta information to use for the conversion.
+
+    Returns:
+        Github_Reference: The converted GitHub reference.
+    """
+    if os.path.isfile(file_ref.filename) or os.path.isdir(file_ref.filename):
+        return Github_Reference(
+            gh_root=repo_data.remote_url,
+            filename=os.path.relpath(
+                os.path.realpath(file_ref.filename),
+                os.path.realpath(repo_data.root),
+            ),
+            line=file_ref.line,
+            commit=repo_data.commit,
+        )
+    raise FileNotFoundError(f"File {file_ref.filename} does not exist.")
+
+
+def update_items(items: Iterable[Item], repo_data: RepoData):
+    for item in items:
+        if isinstance(item.location, File_Reference):
+            item.location = file_ref_to_remote_ref(item.location, repo_data)
+
+
+def update_lobster_file(file: str, repo_data: RepoData, out_file: str):
+    """
+    Update the LOBSTER report file to use GitHub references.
+
+    Args:
+        file (str): Path to the input LOBSTER report file.
+        repo_data (RepoData): object containing remote URL, root path,
+                              and commit hash.
+        out_file (str): Output file for the updated LOBSTER report.
+    """
+    report = Report()
+    report.load_report(file)
+    update_items(report.items.values(), repo_data)
+    report.write_report(out_file)
+    print(f"LOBSTER report {out_file} created, using remote URL references.")
+
+
+ap = argparse.ArgumentParser(
+    description="Update file locations in LOBSTER report to GitHub references.",
+)
+
+
+@get_version(ap)
+def main():
+    ap.add_argument(dest="report",
+                    metavar="LOBSTER_REPORT",
+                    help="Path to the input LOBSTER report file.")
+    ap.add_argument("--repo-root", required=True,
+                    help="Local path to the root of the repository.")
+    ap.add_argument("--remote-url", required=True,
+                    help="GitHub repository root URL.")
+    ap.add_argument("--commit", required=True,
+                    help="Git commit hash to use for the references.")
+    ap.add_argument("--out", required=True, metavar="OUTPUT_FILE",
+                    help="Output file for the updated LOBSTER report."
+                         "It can be the same as the input file in order to "
+                         "overwrite the input file.",)
+    options = ap.parse_args()
+    update_lobster_file(
+        file=options.report,
+        repo_data=RepoData(
+            remote_url=options.remote_url,
+            root=options.repo_root,
+            commit=options.commit,
+        ),
+        out_file=options.out,
+    )

--- a/packages/lobster-core/README.md
+++ b/packages/lobster-core/README.md
@@ -14,14 +14,34 @@ You can generate a report linking everything together with `lobster-report`.
 The report is in JSON, but you can generate more readable versions of it
 with additional tools:
 
-* `lobster-online-report`: Preprocess a JSON report to contain github
-  references instead of local file references
+* `lobster-online-report`:
+  Preprocess a JSON report to contain github references instead of local file
+  references.
+  Repository information is retrieved by calling the `git` tool.
+* `lobster-online-report-nogit`:
+  This tool is similar to `lobster-online-report`, but it does not
+  call the `git` tool to obtain information about the repository.
+  Instead, it relies solely on information provided by the user through
+  command line arguments.
+  The user has to provide
+  - the git hash,
+  - the remote repository URL,
+  - the local path to the repository.
+  
+  The tool then replaces local paths in a given LOBSTER report file
+  with URLs to the corresponding files in the remote repository.
+  
+  This tool is handy when `lobster-online-report` cannot be used.
+  This could be the case in a continuous integration (CI) system where
+  access to `git` is restricted for security reasons.
+  Imagine a CI job that runs with high credentials.
+  It could be important to prevent manipulations of the git history by the CI job,
+  and as a consequence access to `git` is restricted for the job runner.
 * `lobster-html-report`: Generate an HTML report
 * `lobster-ci-report`: Generate a compiler-message like output, useful for CI
 
 ## Requirements
-* `lobster-online-report`: This tool needs `git 1.7.8` or higher to support 
-  git submodules
+`lobster-online-report` needs `git 1.7.8` or higher to support git submodules.
 
 ## Copyright & License information
 

--- a/packages/lobster-core/setup.py
+++ b/packages/lobster-core/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import re
-import sys
 import setuptools
 
 from lobster import version
@@ -51,6 +50,7 @@ setuptools.setup(
               "lobster.tools.core.ci_report",
               "lobster.tools.core.html_report",
               "lobster.tools.core.online_report",
+              "lobster.tools.core.online_report_nogit",
               "lobster.tools.core.report"],
     package_data={
         "lobster.tools.core.html_report":["assets/*"]
@@ -70,6 +70,7 @@ setuptools.setup(
             "lobster-report=lobster.tools.core.report.report:main",
             "lobster-html-report=lobster.tools.core.html_report.html_report:main",
             "lobster-online-report=lobster.tools.core.online_report.online_report:main",
+            "lobster-online-report-nogit=lobster.tools.core.online_report_nogit.online_report_nogit:main",
             "lobster-ci-report=lobster.tools.core.ci_report.ci_report:main"
         ]
     },

--- a/packages/lobster-monolithic/setup.py
+++ b/packages/lobster-monolithic/setup.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 
-import os
 import re
-import sys
 import setuptools
-import glob
 
 from lobster import version
 
@@ -71,6 +68,7 @@ setuptools.setup(
             "lobster-report=lobster.tools.core.report.report:main",
             "lobster-html-report=lobster.tools.core.html_report.html_report:main",
             "lobster-online-report=lobster.tools.core.online_report.online_report:main",
+            "lobster-online-report-nogit=lobster.tools.core.online_report_nogit.online_report_nogit:main",
             "lobster-ci-report=lobster.tools.core.ci_report.ci_report:main",
             "lobster-codebeamer = lobster.tools.codebeamer.codebeamer:main",
             "lobster-python = lobster.tools.python.python:main",

--- a/tests-system/.gitignore
+++ b/tests-system/.gitignore
@@ -2,6 +2,7 @@
 !lobster-html-report/**/input/*.lobster
 !lobster-online-report/**/input/*.lobster
 !lobster-online-report/data/*.lobster
+!lobster-online-report-nogit/data/*.lobster
 !lobster-report/data/*.lobster
 !lobster-trlc/data/*.lobster
 !lobster-codebeamer/data/*.lobster

--- a/tests-system/asserter.py
+++ b/tests-system/asserter.py
@@ -50,7 +50,7 @@ class Asserter:
         a) Replace Windows-like slashes \\ with / in order to be able to
            compare the actual output on all OS against the expected output on
            Linux
-        b) Replace the fixed string TEST_CASE_PATH with the absolute path to
+        b) Replace the fixed string CURRENT_WORKING_DIRECTORY with the absolute path to
            the current working directory. This is necessary for tools like
            lobster-cpptest which write absolute paths into their *.lobster
            output files.

--- a/tests-system/lobster-online-report-nogit/data/maxi-expected.lobster
+++ b/tests-system/lobster-online-report-nogit/data/maxi-expected.lobster
@@ -1,0 +1,217 @@
+{
+  "schema": "lobster-report",
+  "version": 2,
+  "generator": "lobster_report",
+  "levels": [
+    {
+      "name": "level A",
+      "kind": "implementation",
+      "items": [
+        {
+          "tag": "imp tag01",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://plate.cup.fork",
+            "commit": "spoonspoonspoonspoonspoonspoonspoonspoon",
+            "file": "file_01.txt",
+            "line": 1
+          },
+          "name": "name of tag01",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "JUSTIFIED",
+          "language": "language_01",
+          "kind": "kind_01"
+        },
+        {
+          "tag": "imp tag02",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://plate.cup.fork",
+            "commit": "spoonspoonspoonspoonspoonspoonspoonspoon",
+            "file": "file_02.txt",
+            "line": 2
+          },
+          "name": "name of tag02",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "OK",
+          "language": "language_02",
+          "kind": "kind_02"
+        }
+      ],
+      "coverage": 0.0
+    },
+    {
+      "name": "level B",
+      "kind": "activity",
+      "items": [
+        {
+          "tag": "act tag03",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://plate.cup.fork",
+            "commit": "spoonspoonspoonspoonspoonspoonspoonspoon",
+            "file": "file_03.txt",
+            "line": 3
+          },
+          "name": "tag03",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "PARTIAL",
+          "framework": "framework_03",
+          "kind": "kind_03",
+          "status": null
+        },
+        {
+          "tag": "act tag04",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://plate.cup.fork",
+            "commit": "spoonspoonspoonspoonspoonspoonspoonspoon",
+            "file": "file_04.txt",
+            "line": 4
+          },
+          "name": "tag04",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "MISSING",
+          "framework": "framework_04",
+          "kind": "kind_04",
+          "status": null
+        }
+      ],
+      "coverage": 0.0
+    },
+    {
+      "name": "level C",
+      "kind": "requirements",
+      "items": [
+        {
+          "tag": "req tag05",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://plate.cup.fork",
+            "commit": "spoonspoonspoonspoonspoonspoonspoonspoon",
+            "file": "file_05.txt",
+            "line": 5
+          },
+          "name": "name of tag05",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "ERROR",
+          "framework": "framework_05",
+          "kind": "kind_05",
+          "text": "text 05",
+          "status": null
+        },
+        {
+          "tag": "req tag06",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://plate.cup.fork",
+            "commit": "spoonspoonspoonspoonspoonspoonspoonspoon",
+            "file": "very/deeply/nested/file_06.txt",
+            "line": 6
+          },
+          "name": "name of tag06",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "OK",
+          "framework": "framework_06",
+          "kind": "kind_06",
+          "text": "text 06",
+          "status": null
+        }
+      ],
+      "coverage": 0.0
+    },
+    {
+      "name": "level D",
+      "kind": "requirements",
+      "items": [
+        {
+          "tag": "req tag07",
+          "location": {
+            "kind": "codebeamer",
+            "cb_root": "https://the.server.07",
+            "tracker": 77,
+            "item": 7,
+            "version": 777,
+            "name": "name of tag07"
+          },
+          "name": "name of tag07",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "OK",
+          "framework": "framework_07",
+          "kind": "kind_07",
+          "text": "text 07",
+          "status": null
+        }
+      ],
+      "coverage": 0.0
+    }
+  ],
+  "policy": {
+    "level A": {
+      "name": "level A",
+      "kind": "implementation",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_a.lobster",
+          "filters": []
+        }
+      ]
+    },
+    "level B": {
+      "name": "level B",
+      "kind": "activity",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_b.lobster",
+          "filters": []
+        }
+      ]
+    },
+    "level C": {
+      "name": "level C",
+      "kind": "requirements",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_c.lobster",
+          "filters": []
+        }
+      ]
+    },
+    "level D": {
+      "name": "level D",
+      "kind": "requirements",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_d.lobster",
+          "filters": []
+        }
+      ]
+    }
+  },
+  "matrix": []
+}

--- a/tests-system/lobster-online-report-nogit/data/maxi.lobster
+++ b/tests-system/lobster-online-report-nogit/data/maxi.lobster
@@ -1,0 +1,176 @@
+{
+  "schema": "lobster-report",
+  "version": 2,
+  "generator": "lobster_report",
+  "levels": [
+    {
+      "name": "level A",
+      "kind": "implementation",
+      "items": [
+        {
+          "tag": "imp tag01",
+          "location": {
+            "kind": "file",
+            "file": "file_01.txt",
+            "line": 1,
+            "column": null
+          },
+          "name": "name of tag01",
+          "tracing_status": "JUSTIFIED",
+          "language": "language_01",
+          "kind": "kind_01"
+        },
+        {
+          "tag": "imp tag02",
+          "location": {
+            "kind": "file",
+            "file": "file_02.txt",
+            "line": 2,
+            "column": null
+          },
+          "name": "name of tag02",
+          "tracing_status": "OK",
+          "language": "language_02",
+          "kind": "kind_02"
+        }
+      ],
+      "coverage": 0.0
+    },
+    {
+      "name": "level B",
+      "kind": "activity",
+      "items": [
+        {
+          "tag": "act tag03",
+          "location": {
+            "kind": "file",
+            "file": "file_03.txt",
+            "line": 3,
+            "column": null
+          },
+          "tracing_status": "PARTIAL",
+          "framework": "framework_03",
+          "kind": "kind_03"
+        },
+        {
+          "tag": "act tag04",
+          "location": {
+            "kind": "file",
+            "file": "file_04.txt",
+            "line": 4,
+            "column": null
+          },
+          "tracing_status": "MISSING",
+          "framework": "framework_04",
+          "kind": "kind_04"
+        }
+      ],
+      "coverage": 0.0
+    },
+    {
+      "name": "level C",
+      "kind": "requirements",
+      "items": [
+        {
+          "tag": "req tag05",
+          "location": {
+            "kind": "file",
+            "file": "file_05.txt",
+            "line": 5,
+            "column": null
+          },
+          "name": "name of tag05",
+          "tracing_status": "ERROR",
+          "framework": "framework_05",
+          "kind": "kind_05",
+          "text": "text 05"
+        },
+        {
+          "tag": "req tag06",
+          "location": {
+            "kind": "file",
+            "file": "very/deeply/nested/file_06.txt",
+            "line": 6,
+            "column": null
+          },
+          "name": "name of tag06",
+          "tracing_status": "OK",
+          "framework": "framework_06",
+          "kind": "kind_06",
+          "text": "text 06"
+        }
+      ],
+      "coverage": 0.0
+    },
+    {
+      "name": "level D",
+      "kind": "requirements",
+      "items": [
+        {
+          "tag": "req tag07",
+          "location": {
+            "kind": "codebeamer",
+            "cb_root": "https://the.server.07",
+            "tracker": 77,
+            "item": 7,
+            "version": 777,
+            "name": "name of tag07"
+          },
+          "name": "name of tag07",
+          "tracing_status": "OK",
+          "framework": "framework_07",
+          "kind": "kind_07",
+          "text": "text 07"
+        }
+      ],
+      "coverage": 0.0
+    }
+  ],
+  "policy": {
+    "level A": {
+      "name": "level A",
+      "kind": "implementation",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_a.lobster",
+          "filters": []
+        }
+      ]
+    },
+    "level B": {
+      "name": "level B",
+      "kind": "activity",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_b.lobster",
+          "filters": []
+        }
+      ]
+    },
+    "level C": {
+      "name": "level C",
+      "kind": "requirements",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_c.lobster",
+          "filters": []
+        }
+      ]
+    },
+    "level D": {
+      "name": "level D",
+      "kind": "requirements",
+      "traces": [],
+      "source": [
+        {
+          "file": "level_d.lobster",
+          "filters": []
+        }
+      ]
+    }
+  },
+  "matrix": []
+}

--- a/tests-system/lobster-online-report-nogit/data/mini-expected.lobster
+++ b/tests-system/lobster-online-report-nogit/data/mini-expected.lobster
@@ -1,0 +1,46 @@
+{
+  "schema": "lobster-report",
+  "version": 2,
+  "generator": "lobster_report",
+  "levels": [
+    {
+      "name": "code",
+      "kind": "implementation",
+      "items": [
+        {
+          "tag": "imp tag1",
+          "location": {
+            "kind": "github",
+            "gh_root": "https://Kronos.Beta.Quadrant",
+            "commit": "0000000000000000000000000000000000000000",
+            "file": "mini.lobster",
+            "line": 14
+          },
+          "name": "name of tag1",
+          "messages": [],
+          "just_up": [],
+          "just_down": [],
+          "just_global": [],
+          "tracing_status": "JUSTIFIED",
+          "language": "Klingon",
+          "kind": "Fiction"
+        }
+      ],
+      "coverage": 0.0
+    }
+  ],
+  "policy": {
+    "code": {
+      "name": "code",
+      "kind": "implementation",
+      "traces": [],
+      "source": [
+        {
+          "file": "implementation.lobster",
+          "filters": []
+        }
+      ]
+    }
+  },
+  "matrix": []
+}

--- a/tests-system/lobster-online-report-nogit/data/mini.lobster
+++ b/tests-system/lobster-online-report-nogit/data/mini.lobster
@@ -1,0 +1,41 @@
+{
+  "schema": "lobster-report",
+  "version": 2,
+  "generator": "lobster_report",
+  "levels": [
+    {
+      "name": "code",
+      "kind": "implementation",
+      "items": [
+        {
+          "tag": "imp tag1",
+          "location": {
+            "kind": "file",
+            "file": "mini.lobster",
+            "line": 14,
+            "column": null
+          },
+          "name": "name of tag1",
+          "tracing_status": "JUSTIFIED",
+          "language": "Klingon",
+          "kind": "Fiction"
+        }
+      ],
+      "coverage": 0.0
+    }
+  ],
+  "policy": {
+    "code": {
+      "name": "code",
+      "kind": "implementation",
+      "traces": [],
+      "source": [
+        {
+          "file": "implementation.lobster",
+          "filters": []
+        }
+      ]
+    }
+  },
+  "matrix": []
+}

--- a/tests-system/lobster-online-report-nogit/lobster_online_report_nogit_system_test_case_base.py
+++ b/tests-system/lobster-online-report-nogit/lobster_online_report_nogit_system_test_case_base.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Optional, Union
+from .lobster_online_report_nogit_test_runner import LobsterOnlineReportNogitTestRunner
+from ..system_test_case_base import SystemTestCaseBase
+
+
+class LobsterOnlineReportNogitSystemTestCaseBase(SystemTestCaseBase):
+    def __init__(self, methodName):
+        super().__init__(methodName)
+        self._data_directory = Path(__file__).parents[0] / "data"
+
+    def create_test_runner(self) -> LobsterOnlineReportNogitTestRunner:
+        tool_name = Path(__file__).parents[0].name
+        test_runner = LobsterOnlineReportNogitTestRunner(
+            tool_name,
+            self.create_temp_dir(prefix=f"test-{tool_name}-"),
+        )
+        return test_runner

--- a/tests-system/lobster-online-report-nogit/lobster_online_report_nogit_test_runner.py
+++ b/tests-system/lobster-online-report-nogit/lobster_online_report_nogit_test_runner.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+from ..test_runner import TestRunner
+
+
+@dataclass
+class CmdArgs:
+    lobster_report: Optional[str] = None
+    repo_root: Optional[str] = None
+    remote_url: Optional[str] = None
+    commit: Optional[str] = None
+    out: Optional[str] = None
+
+    @staticmethod
+    def _arguments_to_list(argument_map: Iterable[Tuple[str, Optional[str]]]):
+        return [f"{param}={value}"
+                for param, value in argument_map if value is not None]
+
+    def as_list(self) -> List[str]:
+        """Returns the command line arguments as a list"""
+        cmd_args = self._arguments_to_list(
+            (
+                ("--repo-root", self.repo_root),
+                ("--remote-url", self.remote_url),
+                ("--commit", self.commit),
+                ("--out", self.out),
+            )
+        )
+        if self.lobster_report:
+            cmd_args.append(self.lobster_report)
+        return cmd_args
+
+
+class LobsterOnlineReportNogitTestRunner(TestRunner):
+    """System test runner for lobster-online-report-nogit"""
+
+    def __init__(self, tool_name: str, working_dir: Path):
+        super().__init__(tool_name, working_dir)
+        self._cmd_args = CmdArgs()
+
+    @property
+    def cmd_args(self) -> CmdArgs:
+        return self._cmd_args
+
+    def get_tool_args(self) -> List[str]:
+        return self._cmd_args.as_list()

--- a/tests-system/lobster-online-report-nogit/test_nogit.py
+++ b/tests-system/lobster-online-report-nogit/test_nogit.py
@@ -1,0 +1,138 @@
+import json
+import re
+import shutil
+from .lobster_online_report_nogit_system_test_case_base import (
+    LobsterOnlineReportNogitSystemTestCaseBase
+)
+from ..asserter import Asserter
+
+
+class OnlineReportNogitTest(LobsterOnlineReportNogitSystemTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self._test_runner = self.create_test_runner()
+
+    def _create_dummy_files(self, lobster_file: str):
+        """Reads a LOBSTER file and creates one dummy file with a unique name for each
+           item in each level."""
+
+        with open(self._data_directory / lobster_file, "r", encoding="UTF-8") as file:
+            data = json.load(file)
+
+        found_non_file_locations = False
+
+        needed_dummy_files = set()
+        for level in data["levels"]:
+            for item in level["items"]:
+                location = item["location"]
+                if location["kind"] == "file":
+                    item_file_name = location["file"]
+                    if item_file_name in needed_dummy_files:
+                        self.fail(f"Invalid test data: file name '{item_file_name}' "
+                                  f"used multiple times in {lobster_file}!")
+                    needed_dummy_files.add(item_file_name)
+                else:
+                    found_non_file_locations = True
+
+        if not found_non_file_locations:
+            self.fail(f"Invalid test data: The file '{lobster_file}' must contain at "
+                      f"least one location that is not a File_Reference, because the "
+                      f"test shall also verify that non-file locations are not "
+                      f"touched!")
+
+        for file_name in needed_dummy_files:
+            destination = self._test_runner._working_dir / file_name
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.touch()
+
+    def test_path_replacement(self):
+        """Test that file paths (and only them) are replaced with remote URLs"""
+
+        MAXI_LOBSTER = "maxi.lobster"
+        self._create_dummy_files(MAXI_LOBSTER)
+
+        for input_file_name, remote_url, commit in (
+                ("mini.lobster", "https://Kronos.Beta.Quadrant", "0" * 40),
+                (MAXI_LOBSTER, "https://plate.cup.fork", "spoon" * 8),
+        ):
+            with self.subTest(input_file_name=input_file_name):
+                output_file_name = input_file_name.replace(".", "-expected.")
+                input_file_path = self._data_directory / input_file_name
+                self._test_runner.declare_input_file(input_file_path)
+                self._test_runner.declare_output_file(
+                    self._data_directory / output_file_name,
+                )
+
+                cmd_args = self._test_runner.cmd_args
+                cmd_args.out = output_file_name
+                cmd_args.lobster_report = str(input_file_path)
+                cmd_args.commit = commit
+                cmd_args.repo_root = str(self._test_runner.working_dir)
+                cmd_args.remote_url = remote_url
+
+                completed_process = self._test_runner.run_tool_test()
+
+                asserter = Asserter(self, completed_process, self._test_runner)
+                asserter.assertNoStdErrText()
+                asserter.assertStdOutText(
+                    f"LOBSTER report {output_file_name} created, "
+                    f"using remote URL references.\n",
+                )
+                asserter.assertOutputFiles()
+                asserter.assertExitCode(0)
+
+    def test_no_arguments(self):
+        """Test that running without any arguments fails with an error."""
+        completed_process = self._test_runner.run_tool_test()
+        asserter = Asserter(self, completed_process, self._test_runner)
+        asserter.assertExitCode(2)
+
+    def test_one_argument_missing(self):
+        """Test running with one missing argument fails with an error"""
+        cmd_args = self._test_runner.cmd_args
+
+        def init_args_except_one(exception_arg: str):
+            for cmd_arg in vars(cmd_args).keys():
+                if cmd_arg == exception_arg:
+                    setattr(cmd_args, cmd_arg, None)
+                else:
+                    setattr(cmd_args, cmd_arg, f"dummy_value_for_{cmd_arg}")
+
+        for missing_argument in vars(cmd_args).keys():
+            with self.subTest(missing_argument=missing_argument):
+                init_args_except_one(missing_argument)
+                completed_process = self._test_runner.run_tool_test()
+
+                # We compare the actual error message with the expected one,
+                # but we want to ignore dashes and underscores in the cmd argument
+                # names, to simplify the test. They are not important.
+                # Note that named arguments have leading dashes, but positional
+                # arguments do not.
+                # The 'missing_argument' variable does not reflect dashes properly.
+                # Our solution here is to ignore dashes and underscores in the full
+                # string.
+                std_err_no_dash = re.sub(r"[-_]", "", completed_process.stderr).lower()
+                self.assertIn(f"error: the following arguments are required: "
+                              f"{missing_argument.replace('_', '')}", std_err_no_dash)
+                asserter = Asserter(self, completed_process, self._test_runner)
+                asserter.assertNoStdOutText()
+                asserter.assertExitCode(2)
+
+    def test_input_file_not_found(self):
+        input_file = "does_not_exist.lobster"
+        cmd_args = self._test_runner.cmd_args
+        cmd_args.out = "output.lobster"
+        cmd_args.lobster_report = input_file
+        cmd_args.commit = "12" * 20
+        cmd_args.repo_root = "some/path"
+        cmd_args.remote_url = "https://Bajor.Alpha.Quadrant"
+
+        completed_process = self._test_runner.run_tool_test()
+
+        asserter = Asserter(self, completed_process, self._test_runner)
+        self.assertIn(
+            f"No such file or directory: '{input_file}'",
+            completed_process.stderr,
+        )
+        asserter.assertNoStdOutText()
+        asserter.assertExitCode(1)

--- a/tests-system/lobster-online-report/lobster_online_report_system_test_case_base.py
+++ b/tests-system/lobster-online-report/lobster_online_report_system_test_case_base.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional, Union
 from .lobster_online_report_test_runner import LobsterOnlineReportTestRunner
 from ..system_test_case_base import SystemTestCaseBase
 
@@ -8,7 +9,7 @@ class LobsterOnlineReportSystemTestCaseBase(SystemTestCaseBase):
         super().__init__(methodName)
         self._data_directory = Path(__file__).parents[0] / "data"
 
-    def create_test_runner(self, working_dir: str = None) -> (
+    def create_test_runner(self, working_dir: Optional[Union[str, Path]] = None) -> (
             LobsterOnlineReportTestRunner):
         tool_name = Path(__file__).parents[0].name
         if not working_dir:

--- a/tests-system/system_test_case_base.py
+++ b/tests-system/system_test_case_base.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List
+from typing import List, Optional, Union
 from unittest import TestCase
 
 
@@ -10,7 +10,10 @@ class SystemTestCaseBase(TestCase):
         self.maxDiff = None  # pylint: disable=invalid-name
         self._temp_dirs: List[TemporaryDirectory] = []
 
-    def create_temp_dir(self, prefix: str, dir_path: str = None) -> Path:
+    def create_temp_dir(
+            self,
+            prefix: str, dir_path: Optional[Union[str, Path]] = None,
+    ) -> Path:
         # lobster-trace: system_test.Create_Temporary_Directory
         # pylint: disable=consider-using-with
         temp_dir = TemporaryDirectory(prefix=prefix, dir=dir_path)


### PR DESCRIPTION
This new tool is similar to `lobster-online-report`, but it does not call the `git` tool to obtain information about the repository.

Instead, it relies solely on information provided by the user through command line arguments.
The user has to provide
- the git hash,
- the remote repository URL,
- the local path to the repository.

The tool then replaces local paths in a given LOBSTER report file with URLs to the same files in the remote repository.

This tool is handy when `lobster-online-report` cannot be used. This could be the case in a CI system where access to `git` is restricted for security reasons.