### PR TITLE
Modified `packages` make target to clean only affected folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ style:
 		--exclude=assets.py
 
 packages:
-	git clean -xdf
+	git clean -xdf packages test_install test_install_monolithic
 	make lobster/html/assets.py
 	make -C packages/lobster-core
 	make -C packages/lobster-tool-trlc


### PR DESCRIPTION
The `packages` make target previously cleaned the whole repository, including untrackted files that were listed in `.gitignore`, like the `.vscode` folder.

The clean command has now been limited to the following folders:
- packages
- test_install
- test_install_monolithic