### PR TITLE
Request History for CB Mock Server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,13 +93,15 @@ integration-tests: packages
 	(cd tests-integration/projects/coverage-zero; make)
 	rm -f MODULE.bazel MODULE.bazel.lock
 
-system-tests:
-	@echo "🔐 Generating cert.pem and key.pem for system tests..."
+codebeamer-pem:
+	@echo "🔐 Generating cert.pem and key.pem for codebeamer system tests..."
 	@mkdir -p tests-system/lobster-codebeamer/data/ssl
 	@openssl req -x509 -newkey rsa:2048 -nodes \
 		-keyout tests-system/lobster-codebeamer/data/ssl/key.pem \
 		-out tests-system/lobster-codebeamer/data/ssl/cert.pem \
 		-days 365 -subj "//CN=localhost" > /dev/null 2>&1
+
+system-tests: codebeamer-pem
 	mkdir -p docs
 	python -m unittest discover -s tests-system -v -t .
 	make -B -C tests-system TOOL=lobster-python

--- a/lobster/tools/codebeamer/import_query.trlc
+++ b/lobster/tools/codebeamer/import_query.trlc
@@ -3,7 +3,8 @@ import req
 
 req.System_Requirement Query_Id_Parameter {
   description = '''
-    IF an element given through the yaml config file option "import_query" is a valid codebeamer query id,
+    IF an element given through the yaml config file option "import_query" is a valid codebeamer query id
+    (integer greater than zero),
     THEN the tool shall request items from the codebeamer server with the given query id
     AND write the obtained codebeamer items in the LOBSTER interchange format to the file given in the "out" parameter
   '''

--- a/tests-system/lobster-codebeamer/lobster_codebeamer_asserter.py
+++ b/tests-system/lobster-codebeamer/lobster_codebeamer_asserter.py
@@ -1,19 +1,33 @@
 import math
+from typing import Optional
 from ..asserter import Asserter
 
 
 class LobsterCodebeamerAsserter(Asserter):
-    def assertStdOutNumAndFile(self, num_items: int = 1,
-                               out_file: str = "codebeamer.lobster",
-                               page_size: int = 1):
+    def assertStdOutNumAndFile(
+            self,
+            num_items: int,
+            page_size: int,
+            out_file: str = "codebeamer.lobster",
+            import_query: Optional[int] = None,
+    ):
         if num_items == 0:
+            if import_query is None:
+                self._test_case.fail("Invalid assertion call: If zero items are "
+                                     "expected then the import query must be provided!")
+            if not isinstance(import_query, int):
+                # The URL is constructed in a different way for string import_query
+                # and this function does not support this yet.
+                raise NotImplementedError("Having a string as import_query is not "
+                                          "supported yet by the test framework.")
             message = (
                 f"Fetching page 1 of query...\n"
                 f"This query doesn't generate items. Please check:\n"
                 f" * is the number actually correct?\n"
                 f" * do you have permissions to access it?\n"
                 f"You can try to access 'https://localhost:8999/api/v3/reports"
-                f"/1234458/items?page=1&pageSize={page_size}' manually to check.\n"
+                f"/{import_query}/items?page=1&pageSize={page_size}' manually to "
+                f"check.\n"
                 f"Written 0 requirements to {out_file}\n"
             )
         else:

--- a/tests-system/lobster-codebeamer/lobster_codebeamer_system_test_case_base.py
+++ b/tests-system/lobster-codebeamer/lobster_codebeamer_system_test_case_base.py
@@ -17,17 +17,6 @@ class LobsterCodebeamerSystemTestCaseBase(SystemTestCaseBase):
         )
         return test_runner
 
-    def set_config_file_data(self, retry_codes=None, num_retries=None):
-        cfg = self._test_runner.config_file_data
-        cfg.import_query = 1234458
-        cfg.root = "https://localhost:8999"
-        cfg.token = "abcdef1234567890"
-        cfg.out = "codebeamer.lobster"
-        if retry_codes is not None:
-            cfg.retry_error_codes = retry_codes
-        if num_retries is not None:
-            cfg.num_request_retry = num_retries
-
     def create_mock_response_items(self, page: int, page_size: int, total: int):
         """Create a mock response like codebeamer API paginated items."""
         MULTIPLICATOR = 100

--- a/tests-system/lobster-codebeamer/lobster_codebeamer_test_runner.py
+++ b/tests-system/lobster-codebeamer/lobster_codebeamer_test_runner.py
@@ -1,21 +1,27 @@
 from subprocess import CompletedProcess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 import yaml
+from .mock_server import PORT
 from ..test_runner import TestRunner
 
 
 @dataclass
 class ConfigFileData:
-    import_query: Optional[bool] = None
+    import_query: Optional[Union[int, str]] = None
     root: Optional[str] = None
     token: Optional[str] = None
     out: Optional[str] = None
     refs: Optional[List[str]] = None
-    page_size: Optional[str] = None
-    num_request_retry: Optional[bool] = None
-    retry_error_codes: Optional[bool] = None
+    page_size: Optional[int] = None
+    num_request_retry: Optional[int] = None
+    retry_error_codes: Optional[List[int]] = None
+
+    def set_default_root_token_out(self):
+        self.root = f"https://localhost:{PORT}"
+        self.token = "abcdef1234567890"
+        self.out = "codebeamer.lobster"
 
     def dump(self, filename: str):
         data = {}

--- a/tests-system/lobster-codebeamer/mock_server_setup.py
+++ b/tests-system/lobster-codebeamer/mock_server_setup.py
@@ -1,5 +1,5 @@
 import threading
-from .mock_server import create_app
+from .mock_server import CodebeamerFlask, create_app
 
 mock_server_thread = None
 codebeamer_flask = None
@@ -18,5 +18,7 @@ def start_mock_server():
     mock_server_thread.start()
 
 
-def get_mock_app():
+def get_mock_app() -> CodebeamerFlask:
+    if not codebeamer_flask:
+        raise RuntimeError("Mock server not started! Call start_mock_server() first!")
     return codebeamer_flask

--- a/tests-system/lobster-codebeamer/test_lobster_codebeamer.py
+++ b/tests-system/lobster-codebeamer/test_lobster_codebeamer.py
@@ -18,8 +18,8 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
 
     def setUp(self):
         super().setUp()
+        self.codebeamer_flask.reset()
         self._test_runner = self.create_test_runner()
-        self.codebeamer_flask.responses = []
 
     def test_retry_if_configured(self):
         """Ensure the tool retries and exits after exhausting
@@ -27,7 +27,11 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
         # lobster-trace: codebeamer_req.Retry_On_Specific_HTTPS_Status_Codes
 
         self.codebeamer_flask.responses = [Response(status=429)] * 3
-        self.set_config_file_data(retry_codes=[429], num_retries=3)
+        cfg = self._test_runner.config_file_data
+        cfg.set_default_root_token_out()
+        cfg.retry_error_codes = [429]
+        cfg.num_request_retry = 3
+        cfg.import_query = 999
 
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
@@ -36,8 +40,8 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
             "[Attempt 1/3] Retryable error: 429\n"
             "[Attempt 2/3] Retryable error: 429\n"
             "[Attempt 3/3] Retryable error: 429\n"
-            f"Could not fetch {self._test_runner.config_file_data.root}/api/"
-            "v3/reports/1234458/items?page=1&pageSize=100.\n",
+            f"Could not fetch {cfg.root}/api/"
+            f"v3/reports/{cfg.import_query}/items?page=1&pageSize=100.\n",
             completed_process.stdout,
         )
         asserter.assertExitCode(1)
@@ -76,7 +80,11 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
             Response(status=429),
             Response(json.dumps(response_data), status=200),
         ]
-        self.set_config_file_data(retry_codes=[429], num_retries=3)
+        cfg = self._test_runner.config_file_data
+        cfg.set_default_root_token_out()
+        cfg.retry_error_codes = [429]
+        cfg.num_request_retry = 3
+        cfg.import_query = 123123123123123123
         self._test_runner.declare_output_file(
             self._data_directory / self._test_runner.config_file_data.out)
 
@@ -96,7 +104,9 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
         """Ensure the tool does NOT retry if RETRY_ERROR_CODES is not defined."""
         # lobster-trace: codebeamer_req.Missing_Error_Code
         self.codebeamer_flask.responses = [Response(status=429)]
-        self.set_config_file_data()
+        cfg = self._test_runner.config_file_data
+        cfg.set_default_root_token_out()
+        cfg.import_query = 1111
 
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
@@ -104,7 +114,7 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
         self.assertIn(
             "[Attempt 1/5] Failed with status 429\n"
             f"Could not fetch {self._test_runner.config_file_data.root}/"
-            "api/v3/reports/1234458/items?page=1&pageSize=100.\n",
+            f"api/v3/reports/{cfg.import_query}/items?page=1&pageSize=100.\n",
             completed_process.stdout,
         )
         self.assertNotIn("Retrying request", completed_process.stdout)

--- a/tests-system/lobster-codebeamer/test_valid_flow.py
+++ b/tests-system/lobster-codebeamer/test_valid_flow.py
@@ -17,12 +17,14 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
 
     def setUp(self):
         super().setUp()
+        self.codebeamer_flask.reset()
         self._test_runner = self.create_test_runner()
-        self.codebeamer_flask.responses = []
 
     def test_valid_query_id(self):
         # lobster-trace: codebeamer_req.Query_Id_Parameter
-        self.set_config_file_data()
+        cfg = self._test_runner.config_file_data
+        cfg.set_default_root_token_out()
+        cfg.import_query = 10203
         self._test_runner.declare_output_file(
             self._data_directory / self._test_runner.config_file_data.out)
 
@@ -58,13 +60,18 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
 
         completed_process = self._test_runner.run_tool_test()
         asserter = LobsterCodebeamerAsserter(self, completed_process, self._test_runner)
-        asserter.assertStdOutNumAndFile()
+        asserter.assertStdOutNumAndFile(
+            num_items=len(response_data['items']),
+            page_size=1,
+        )
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
 
     def test_references_tracing_tag_added(self):
         # lobster-trace: codebeamer_req.References_Field_Support
-        self.set_config_file_data()
+        cfg = self._test_runner.config_file_data
+        cfg.set_default_root_token_out()
+        cfg.import_query = 424242
         self._test_runner.config_file_data.refs = ["Wife", "Husband"]
 
         response_data = {
@@ -104,6 +111,9 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
 
         completed_process = self._test_runner.run_tool_test()
         asserter = LobsterCodebeamerAsserter(self, completed_process, self._test_runner)
-        asserter.assertStdOutNumAndFile()
+        asserter.assertStdOutNumAndFile(
+            num_items=len(response_data['items']),
+            page_size=1,
+        )
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()

--- a/tests-unit/lobster-codebeamer/test_codebeamer.py
+++ b/tests-unit/lobster-codebeamer/test_codebeamer.py
@@ -170,7 +170,6 @@ class QueryCodebeamerTest(unittest.TestCase):
 
     @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')
     def test_import_tagged(self, mock_query_cb_single):
-        # lobster-trace: codebeamer_req.Dummy_Requirement_Unit_Test
         item_ids = (24406947, 21747817)
         response_items = [
             {


### PR DESCRIPTION
The codebeamer mock server now stores a history of the received HTTP requests.
This way it is now possible to test that `lobster-codebeamer` sends the correct requests.
Previously it was only possible to test if the answers from the mock server have been
digested properly by `lobster-codebeamer`, but it was not possibly to verify that the
initial requests sent to the server were correct.

Updated test `test_extract_requirements_scenarios` to verify that `lobster-codebeamer`
has sent the expected requests in the correct order with the correct page size parameter
to the mock server.

Also added an exception in case the system test framework tries to fetch the
CB mock server instance before the server is aktually started.

Introduced new make target to generate SSL certificates for the codebeamer mock server.
This makes it handy to generate them on a developer client with just one command.

Fixed type hints.

Method `set_config_file_data` in class `LobsterCodebeamerSystemTestCaseBase` made the
assumption that member variable `_test_runner` existed. The function has been deleted
to resolve the issue. Instead, the class `ConfigFileData` now offers a member function
to set default values for "root", "token" and "out".

Specified what a "valid" codebeamer query ID is in requirement `codebeamer_req.Query_Id_Parameter`.