### PR TITLE
Fix the return type for create_output_directory_and_copy_expected function

### DIFF
--- a/tests-system/lobster-cpptest/test_directories.py
+++ b/tests-system/lobster-cpptest/test_directories.py
@@ -30,13 +30,13 @@ class DirectoriesCpptestTest(LobsterCpptestSystemTestCaseBase):
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
 
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
         self._test_runner.cmd_args.config = str(
             self._data_directory / "nested_directories.yaml")
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 
@@ -60,13 +60,13 @@ class DirectoriesCpptestTest(LobsterCpptestSystemTestCaseBase):
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
 
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
         self._test_runner.cmd_args.config = str(
             self._data_directory / "specific_directory_config.yaml")
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 
@@ -93,13 +93,13 @@ class DirectoriesCpptestTest(LobsterCpptestSystemTestCaseBase):
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
 
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
         self._test_runner.cmd_args.config = str(
             self._data_directory / "directory_files_config.yaml")
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 

--- a/tests-system/lobster-cpptest/test_extension.py
+++ b/tests-system/lobster-cpptest/test_extension.py
@@ -24,11 +24,11 @@ class ExtensionCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 
@@ -49,11 +49,11 @@ class ExtensionCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 

--- a/tests-system/lobster-cpptest/test_multiple_files.py
+++ b/tests-system/lobster-cpptest/test_multiple_files.py
@@ -32,11 +32,11 @@ class MultipleFilesCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 
@@ -67,11 +67,11 @@ class MultipleFilesCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 

--- a/tests-system/lobster-cpptest/test_references.py
+++ b/tests-system/lobster-cpptest/test_references.py
@@ -21,11 +21,11 @@ class ReferencesCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 
@@ -45,11 +45,11 @@ class ReferencesCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 
@@ -70,11 +70,11 @@ class ReferencesCpptestTest(LobsterCpptestSystemTestCaseBase):
 
         self.output_dir = self.create_output_directory_and_copy_expected(
             self.output_dir, Path(self._data_directory / OUT_FILE))
-        self._test_runner.declare_output_file(Path(self.output_dir.name) /
+        self._test_runner.declare_output_file(self.output_dir /
                                               OUT_FILE)
 
         update_cpptest_output_file(
-            Path(self.output_dir.name) / OUT_FILE,
+            self.output_dir / OUT_FILE,
             self._test_runner.working_dir
         )
 

--- a/tests-system/system_test_case_base.py
+++ b/tests-system/system_test_case_base.py
@@ -36,8 +36,9 @@ class SystemTestCaseBase(TestCase):
         output_dir = TemporaryDirectory(dir=output_dir)
         self._temp_dirs.append(output_dir)
         # Copy Expected output to temporary folder to compare with the output
-        shutil.copy(expected_file, Path(output_dir.name))
-        return output_dir
+        output_dir_path = Path(output_dir.name)
+        shutil.copy(expected_file, output_dir_path)
+        return output_dir_path
 
     def tearDown(self):
         # lobster-trace: system_test.Delete_Temporary_Directory


### PR DESCRIPTION
The return type for Fuction `create_output_directory_and_copy_expected ` was TemporaryDirectory which then required to be converted to `Path` in every testcase where the function was used. Now the function itself returns Path type.