### PR TITLE
Improve file error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 
 ### 0.13.1-dev
 
-
+* `lobster-online-report-nogit`:
+  - Improved the error message in case a file is not found.
+    The tool exits with return code 1 instead of crashing with an exception.
 
 ### 0.13.0
 

--- a/lobster/tools/core/online_report_nogit/online_report_nogit.py
+++ b/lobster/tools/core/online_report_nogit/online_report_nogit.py
@@ -1,7 +1,10 @@
 import argparse
 import os.path
+import sys
+
 from dataclasses import dataclass
 from typing import Iterable
+
 from lobster.items import Item
 from lobster.location import File_Reference, Github_Reference
 from lobster.report import Report
@@ -45,7 +48,7 @@ def file_ref_to_remote_ref(file_ref: File_Reference, repo_data: RepoData) -> (
             line=file_ref.line,
             commit=repo_data.commit,
         )
-    raise FileNotFoundError(f"File {file_ref.filename} does not exist.")
+    raise FileNotFoundError(f"File '{file_ref.filename}' does not exist.")
 
 
 def update_items(items: Iterable[Item], repo_data: RepoData):
@@ -92,12 +95,22 @@ def main():
                          "It can be the same as the input file in order to "
                          "overwrite the input file.",)
     options = ap.parse_args()
-    update_lobster_file(
-        file=options.report,
-        repo_data=RepoData(
-            remote_url=options.remote_url,
-            root=options.repo_root,
-            commit=options.commit,
-        ),
-        out_file=options.out,
-    )
+
+    try:
+        update_lobster_file(
+            file=options.report,
+            repo_data=RepoData(
+                remote_url=options.remote_url,
+                root=options.repo_root,
+                commit=options.commit,
+            ),
+            out_file=options.out,
+        )
+    except FileNotFoundError as e:
+        print(
+            f"Error: {e}\n"
+            f"Note: Relative paths are resolved with respect to the "
+            f"current working directory '{os.getcwd()}'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/tests-system/lobster-online-report-nogit/data/invalid-ref.lobster
+++ b/tests-system/lobster-online-report-nogit/data/invalid-ref.lobster
@@ -1,14 +1,14 @@
 {
   "schema": "lobster-report",
   "version": 2,
-  "generator": "lobster_report",
+  "generator": "sparrow",
   "levels": [
     {
       "name": "code",
       "kind": "implementation",
       "items": [
         {
-          "tag": "imp tag1",
+          "tag": "imp tag-in-file-which-does-not-exist",
           "location": {
             "kind": "file",
             "file": "does-not-exist.file",
@@ -17,8 +17,8 @@
           },
           "name": "name of file which does not exist",
           "tracing_status": "JUSTIFIED",
-          "language": "Python",
-          "kind": "Expert"
+          "language": "French",
+          "kind": "beautiful"
         }
       ],
       "coverage": 0.0

--- a/tests-system/lobster-online-report-nogit/data/invalid-ref.lobster
+++ b/tests-system/lobster-online-report-nogit/data/invalid-ref.lobster
@@ -1,0 +1,41 @@
+{
+  "schema": "lobster-report",
+  "version": 2,
+  "generator": "lobster_report",
+  "levels": [
+    {
+      "name": "code",
+      "kind": "implementation",
+      "items": [
+        {
+          "tag": "imp tag1",
+          "location": {
+            "kind": "file",
+            "file": "does-not-exist.file",
+            "line": 8,
+            "column": null
+          },
+          "name": "name of file which does not exist",
+          "tracing_status": "JUSTIFIED",
+          "language": "Python",
+          "kind": "Expert"
+        }
+      ],
+      "coverage": 0.0
+    }
+  ],
+  "policy": {
+    "code": {
+      "name": "code",
+      "kind": "implementation",
+      "traces": [],
+      "source": [
+        {
+          "file": "implementation.lobster",
+          "filters": []
+        }
+      ]
+    }
+  },
+  "matrix": []
+}

--- a/tests-system/lobster-online-report-nogit/lobster_online_report_nogit_system_test_case_base.py
+++ b/tests-system/lobster-online-report-nogit/lobster_online_report_nogit_system_test_case_base.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional, Union
 from .lobster_online_report_nogit_test_runner import LobsterOnlineReportNogitTestRunner
 from ..system_test_case_base import SystemTestCaseBase
 

--- a/tests-system/lobster-online-report-nogit/test_nogit.py
+++ b/tests-system/lobster-online-report-nogit/test_nogit.py
@@ -147,8 +147,7 @@ class OnlineReportNogitTest(LobsterOnlineReportNogitSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
 
         asserter = Asserter(self, completed_process, self._test_runner)
-        expected_path = os.path.normcase(os.path.normpath(
-            os.path.realpath(self._test_runner.working_dir)))
+        expected_path = str(self._test_runner.working_dir)
         asserter.assertStdErrText(
             f"Error: File 'does-not-exist.file' does not exist.\n"
             f"Note: Relative paths are resolved with respect to the "

--- a/tests-system/lobster-online-report-nogit/test_nogit.py
+++ b/tests-system/lobster-online-report-nogit/test_nogit.py
@@ -1,6 +1,6 @@
 import json
 import re
-import shutil
+import os
 from .lobster_online_report_nogit_system_test_case_base import (
     LobsterOnlineReportNogitSystemTestCaseBase
 )
@@ -133,6 +133,26 @@ class OnlineReportNogitTest(LobsterOnlineReportNogitSystemTestCaseBase):
         self.assertIn(
             f"No such file or directory: '{input_file}'",
             completed_process.stderr,
+        )
+        asserter.assertNoStdOutText()
+        asserter.assertExitCode(1)
+
+    def test_referenced_file_not_found(self):
+        cmd_args = self._test_runner.cmd_args
+        cmd_args.out = "output.lobster"
+        cmd_args.lobster_report = str(self._data_directory / "invalid-ref.lobster")
+        cmd_args.commit = "abc"
+        cmd_args.repo_root = str(self._test_runner.working_dir)
+        cmd_args.remote_url = "https://A.B.C"
+        completed_process = self._test_runner.run_tool_test()
+
+        asserter = Asserter(self, completed_process, self._test_runner)
+        expected_path = os.path.normcase(os.path.normpath(
+            os.path.realpath(self._test_runner.working_dir)))
+        asserter.assertStdErrText(
+            f"Error: File 'does-not-exist.file' does not exist.\n"
+            f"Note: Relative paths are resolved with respect to the "
+            f"current working directory '{expected_path}'.\n",
         )
         asserter.assertNoStdOutText()
         asserter.assertExitCode(1)

--- a/tests-system/system_test_case_base.py
+++ b/tests-system/system_test_case_base.py
@@ -19,7 +19,7 @@ class SystemTestCaseBase(TestCase):
         # pylint: disable=consider-using-with
         temp_dir = TemporaryDirectory(prefix=prefix, dir=dir_path)
         self._temp_dirs.append(temp_dir)
-        return Path(temp_dir.name)
+        return Path(temp_dir.name).resolve()
 
     def create_output_directory_and_copy_expected(self, output_dir: Path,
                                                   expected_file: Path):


### PR DESCRIPTION
`lobster-online-report-nogit` prints the current working directory in case a file is not found. This helps to debug relative paths in CI use cases.

The tool also returns with `sys.exit(1)` instead of crashing with an exception.