### PR TITLE
Remove `sys.exit` calls from `codebeamer.py`

### DIFF
--- a/lobster/tools/codebeamer/exceptions.py
+++ b/lobster/tools/codebeamer/exceptions.py
@@ -1,0 +1,16 @@
+class QueryException(Exception):
+    """This exception is raised when a query to the Codebeamer API fails."""
+
+
+class NotFileException(Exception):
+    """This exception is raised when a file is expected but the path does not point to
+       a file.
+    """
+
+
+class MismatchException(Exception):
+    """This exception is raised when there is a mismatch in the data retrieved from a
+       codebeamer api call.
+       For example, query page 7 has been requested, but the response data indicates
+       page 8.
+    """

--- a/tests-unit/lobster-codebeamer/test_codebeamer.py
+++ b/tests-unit/lobster-codebeamer/test_codebeamer.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from lobster.tools.codebeamer.codebeamer import (CodebeamerError, get_query, get_single_item,
+from lobster.tools.codebeamer.codebeamer import (MismatchException, get_query, get_single_item,
                                                  get_many_items, parse_config_data, to_lobster,
                                                  import_tagged)
 
@@ -124,7 +124,7 @@ class QueryCodebeamerTest(unittest.TestCase):
                 "total": 1,
                 "items": []
             }  
-        with self.assertRaises(CodebeamerError):
+        with self.assertRaises(MismatchException):
             get_query(self._mock_cb_config, query_id)
 
     @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')


### PR DESCRIPTION
Direct calls of `sys.exit` have been removed from the functions in file `codebeamer.py`. They have been replaced with exceptions instead. The `_run_impl` method of the `CodebeamerTool` class catches these exceptions, and sets a proper method return value.

This change continues the work of https://github.com/bmw-software-engineering/lobster/pull/336.