### PR TITLE
Introduce API to convert file references to GitHub references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ### 0.13.1-dev
 
+* API:
+  Introduced an API function called `apply_github_urls`.
+  Instead of running the tool `lobster-online-report-nogit` users
+  can write their own Python scripts and import the function
+  to achieve the same result as when running the tool.
+
 * `lobster-codebeamer`:
   - Add warning message if the file given through the configuration parameter
     `import_tagged` contains references which cannot be converted to integer

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ lint-system-tests: style
 		tests-system/system_test_case_base.py \
 		tests-system/asserter.py \
 		tests-system/lobster-json \
-		tests-system/lobster-report \
 		tests-system/lobster-meta-data-tool-base \
 		tests-system/lobster-online-report \
 		tests-system/lobster-online-report-nogit \

--- a/documentation/manual-lobster_online_report_nogit.md
+++ b/documentation/manual-lobster_online_report_nogit.md
@@ -1,0 +1,28 @@
+# Turning File References into GitHub References
+If you want to publish your LOBSTER report or send it to a colleague,
+then most likely you wish that the report does not contain references to files on your
+local system, but instead it shall use URLs to the files in the remote repository.
+LOBSTER supports GitHub repositories.
+
+There are two tools, `lobster-online-report` and `lobster-online-report-nogit`.
+Both tools replace file references in a `*.lobster` file with GitHub references,
+with the following difference:
+- `lobster-online-report` calls `git` and extracts the necessary information like
+  remote URL by itself,
+- `lobster-online-report-nogit` does not call `git`, but the user provides the
+  necessary information through command line arguments.
+
+Depending on your CI environment one or the other tool mab be better suited.
+
+Example on Windows:
+```
+> lobster-online-report-nogit --repo-root="C:\path\to\repository" --remote-url="https://github.com/bmw-software-engineering/lobster" --commit=af10137b15c98ab6ebde09f4b7fa4ae9e0931bac --out="C:\path\modified_report.lobster" "C:\path\original_report.lobster"
+```
+
+## API
+
+There is also an API function that works similar:
+
+```python
+from lobster.tools.core.online_report_nogit.online_report_nogit import apply_github_urls
+```

--- a/lobster/errors.py
+++ b/lobster/errors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # LOBSTER - Lightweight Open BMW Software Traceability Evidence Report
-# Copyright (C) 2022-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# Copyright (C) 2022-2023, 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -48,9 +48,7 @@ class Message_Handler:
         else:
             self.errors += 1
 
-        print("%s: lobster %s: %s" % (location.to_string(),
-                                      severity,
-                                      message))
+        print(f"{location.to_string()}: lobster {severity}: {message}")
 
     def lex_error(self, location, message):
         assert isinstance(location, Location)

--- a/lobster/location.py
+++ b/lobster/location.py
@@ -170,8 +170,7 @@ class Github_Reference(Location):
 
     def to_string(self):
         if self.line:
-            return "%s:%u" % (self.filename,
-                              self.line)
+            return f"{self.filename}:{self.line}"
         else:
             return self.filename
 
@@ -180,11 +179,8 @@ class Github_Reference(Location):
         if self.line:
             file_ref += "#L%u" % self.line
 
-        return '<a href="%s/blob/%s/%s" target="_blank">%s</a>' % (
-            self.gh_root,
-            self.commit,
-            file_ref,
-            self.to_string())
+        return f'<a href="{self.gh_root}/blob/{self.commit}/{file_ref}" ' \
+               f'target="_blank">{self.to_string()}</a>'
 
     def to_json(self):
         return {"kind"           : "github",

--- a/lobster/tools/core/online_report_nogit/online_report_nogit.py
+++ b/lobster/tools/core/online_report_nogit/online_report_nogit.py
@@ -1,5 +1,5 @@
 import argparse
-import os.path
+import os
 import sys
 
 from dataclasses import dataclass
@@ -13,13 +13,13 @@ from lobster.meta_data_tool_base import MetaDataToolBase
 
 
 @dataclass
-class RepoData:
+class RepoInfo:
     """
     Data class to hold repository information.
 
     Attributes:
         remote_url (str): The root URL of the GitHub repository.
-        repo_root (str): The local path to the root of the repository.
+        root (str): The local path to the root of the repository.
         commit (str): The commit hash to use when building a URL to a file.
     """
     remote_url: str
@@ -27,54 +27,69 @@ class RepoData:
     commit: str
 
 
-def file_ref_to_remote_ref(file_ref: File_Reference, repo_data: RepoData) -> (
-        Github_Reference):
+def _file_ref_to_github_ref(
+        file_ref: File_Reference,
+        repo_info: RepoInfo,
+        paths_must_exist: bool,
+) -> Github_Reference:
     """
     Convert a File_Reference to a Github_Reference.
 
     Args:
-        file_ref (File_Reference): The file reference to convert.
+        file_ref (File_Reference): The file reference to convert (can be a directory).
         repo_data (RepoData): The repository meta information to use for the conversion.
+        paths_must_exist (bool): If True, then a sanity check is performed. If the path
+          is is not a directory and not a file, then a FileNotFoundError is raised.
 
     Returns:
         Github_Reference: The converted GitHub reference.
     """
-    if os.path.isfile(file_ref.filename) or os.path.isdir(file_ref.filename):
+    if (not paths_must_exist) \
+            or os.path.isfile(file_ref.filename) or os.path.isdir(file_ref.filename):
         return Github_Reference(
-            gh_root=repo_data.remote_url,
+            gh_root=repo_info.remote_url,
             filename=quote(
                 os.path.relpath(
                     os.path.realpath(file_ref.filename),
-                    os.path.realpath(repo_data.root),
+                    os.path.realpath(repo_info.root),
                 ).replace(os.sep, "/")
             ),
             line=file_ref.line,
-            commit=repo_data.commit,
+            commit=repo_info.commit,
         )
     raise FileNotFoundError(f"File '{file_ref.filename}' does not exist.")
 
 
-def update_items(items: Iterable[Item], repo_data: RepoData):
+def _update_items(items: Iterable[Item], repo_info: RepoInfo, paths_must_exist: bool):
     for item in items:
         if isinstance(item.location, File_Reference):
-            item.location = file_ref_to_remote_ref(item.location, repo_data)
+            item.location = _file_ref_to_github_ref(
+                item.location,
+                repo_info,
+                paths_must_exist,
+            )
 
 
-def update_lobster_file(file: str, repo_data: RepoData, out_file: str):
+def apply_github_urls(
+        in_file: str,
+        out_file: str,
+        repository_info: RepoInfo,
+        paths_must_exist: bool = True):
     """
-    Update the LOBSTER report file to use GitHub references.
+    Reads a report file, converts all file references to GitHub references,
+    and saves the report.
 
     Args:
         file (str): Path to the input LOBSTER report file.
-        repo_data (RepoData): object containing remote URL, root path,
-                              and commit hash.
         out_file (str): Output file for the updated LOBSTER report.
+        repo_data (RepoData): object containing remote URL, root path, and commit hash.
+        paths_must_exist (bool): If True, then a sanity check is performed. If the path
+          is is not a directory and not a file, then a FileNotFoundError is raised.
     """
     report = Report()
-    report.load_report(file)
-    update_items(report.items.values(), repo_data)
+    report.load_report(in_file)
+    _update_items(report.items.values(), repository_info, paths_must_exist)
     report.write_report(out_file)
-    print(f"LOBSTER report {out_file} created, using remote URL references.")
 
 
 class OnlineReportNogitTool(MetaDataToolBase):
@@ -101,15 +116,16 @@ class OnlineReportNogitTool(MetaDataToolBase):
 
     def _run_impl(self, options: argparse.Namespace) -> int:
         try:
-            update_lobster_file(
-                file=options.report,
-                repo_data=RepoData(
+            apply_github_urls(
+                in_file=options.report,
+                repository_info=RepoInfo(
                     remote_url=options.remote_url,
                     root=options.repo_root,
                     commit=options.commit,
                 ),
                 out_file=options.out,
             )
+            print(f"LOBSTER report {options.out} created, using remote URL references.")
         except FileNotFoundError as e:
             print(
                 f"Error: {e}\n"

--- a/tests-unit/lobster-online-report-nogit/test_online_report_nogit.py
+++ b/tests-unit/lobster-online-report-nogit/test_online_report_nogit.py
@@ -1,0 +1,126 @@
+from os import path
+import os
+from pathlib import Path
+from unittest import TestCase
+from urllib.parse import quote
+from lobster.tools.core.online_report_nogit.online_report_nogit import _file_ref_to_github_ref, RepoInfo
+from lobster.location import File_Reference, Github_Reference
+
+
+class LobsterOnlineReportNogitTest(TestCase):
+    def test_fake_file_conversion(self):
+        """Test that a fake file reference can be converted to GitHub reference
+        
+           Also tests that the URL is built properly regardless of slashes
+           at the end of the input strings.
+        """
+
+        local_root = path.join("path", "to")
+        file_ref = File_Reference(
+            filename=path.join(local_root, "Munich", "Dostlerstraße.werk"),
+            line=123,
+            column=20000000000000,
+        )
+        self.assertFalse(
+            path.isfile(file_ref.filename) or path.isdir(file_ref.filename),
+            "Invalid test setup! The path must not exist!",
+        )
+        repository_name = "seashell"
+        gh_root = f"https://der.server.de/{repository_name}"
+        for append_url_slash in ("/", ""):
+            for append_path_slash in (os.sep, ""):
+                repo_info = RepoInfo(
+                    remote_url=f"{gh_root}{append_url_slash}",
+                    root=f"{local_root}{append_path_slash}",
+                    commit="the-commit-sha"
+                )
+                with self.subTest(f"{append_url_slash=}, {append_path_slash=}"):
+                    result = _file_ref_to_github_ref(
+                        file_ref=file_ref,
+                        repo_info=repo_info,
+                        paths_must_exist=False,
+                    )
+                    self.assertIsInstance(result, Github_Reference)
+                    self.assertEqual(result.gh_root, gh_root)
+                    self.assertEqual(result.gh_repo, repository_name)
+                    self.assertEqual(result.commit, repo_info.commit)
+                    self.assertEqual(result.line, file_ref.line)
+                    escaped_char = quote("ß")
+                    self.assertEqual(result.filename, f"Munich/Dostlerstra{escaped_char}e.werk")
+                    self.assertEqual(
+                        result.to_html(),
+                        f'<a href="{gh_root}/blob/{repo_info.commit}/' \
+                        f'Munich/Dostlerstra{escaped_char}e.werk#L{file_ref.line}" target="_blank">' \
+                        f'Munich/Dostlerstra{escaped_char}e.werk:{file_ref.line}</a>',
+                    )
+
+    def test_real_file_conversion(self):
+        """Test that a path reference of a truly existing path can be converted
+           to GitHub reference
+
+           The test is executed one with a file, and once with a directory.
+           Each time the parameter 'paths_must_exist' is set to True.
+        """
+
+        # Run test on a) file and b) directory. For simplicity we use the current
+        # file and its parent.
+        for path_to_convert in (Path(__file__), Path(__file__).parent):
+            with self.subTest(f"{path_to_convert=}"):
+                file_ref = File_Reference(
+                    filename=str(path_to_convert),
+                    line=1,
+                    column=2,
+                )
+                self.assertTrue(
+                    path.isfile(file_ref.filename) or path.isdir(file_ref.filename),
+                    "Invalid test setup! The path must exist!",
+                )
+                repository_name = "bluewhale"
+                gh_root = f"https://the.other.server.org/{repository_name}"
+                repo_info = RepoInfo(
+                    remote_url=gh_root,
+                    root=str(path_to_convert.parent),
+                    commit="the-nice-guy"
+                )
+                result = _file_ref_to_github_ref(
+                    file_ref=file_ref,
+                    repo_info=repo_info,
+                    paths_must_exist=True,
+                )
+                self.assertIsInstance(result, Github_Reference)
+                self.assertEqual(result.gh_root, gh_root)
+                self.assertEqual(result.gh_repo, repository_name)
+                self.assertEqual(result.commit, repo_info.commit)
+                self.assertEqual(result.line, file_ref.line)
+                self.assertEqual(result.filename, path_to_convert.name,
+                                 "filename mismatch")
+                self.assertEqual(
+                    result.to_html(),
+                    f'<a href="{gh_root}/blob/{repo_info.commit}/' \
+                    f'{path_to_convert.name}#L{file_ref.line}" target="_blank">' \
+                    f'{path_to_convert.name}:{file_ref.line}</a>',
+                    "HTML mismatch"
+                )
+
+    def test_error_on_missing_file(self):
+        """Test that an exception is raised if the path does not exist"""
+        file_ref = File_Reference(
+            filename="does-not-exist",
+            line=1,
+            column=2,
+        )
+        self.assertFalse(
+            path.isfile(file_ref.filename) or path.isdir(file_ref.filename),
+            "Invalid test setup! The path must not exist!",
+        )
+        repo_info = RepoInfo(
+            remote_url="http://abc.def.ghi",
+            root=str(Path(__file__).parent),
+            commit="the-bad-guy"
+        )
+        with self.assertRaises(FileNotFoundError):
+            _file_ref_to_github_ref(
+                file_ref=file_ref,
+                repo_info=repo_info,
+                paths_must_exist=True,
+            )


### PR DESCRIPTION
Introduced an API function called `apply_github_urls`.
Instead of running the tool `lobster-online-report-nogit` users
can write their own Python scripts and import the function there
to achieve the same result as when running the tool.

Also updated a few s-strings to f-strings to follow the coding guideline.