### PR TITLE
Adding make target to lint unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
         echo "trlc any_modified: ${{ steps.changed-trlc-files.outputs.any_modified }}"
         echo "docu only_modified: ${{ steps.changed-docu-files.outputs.only_modified }}"
 
-  lint:
-    name: PyLint
+  lint-code:
+    name: PyLint Code
     needs: changes
     if: ${{ needs.changes.outputs.py_modified == 'true' }}
     runs-on: ubuntu-24.04
@@ -85,9 +85,23 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements_dev.txt
-      - name: Executing linter
+      - name: Executing system test linter
         run: |
           make lint-system-tests
+  lint-unit-tests:
+    name: PyLint Unit Tests
+    needs: changes
+    if: ${{ needs.changes.outputs.py_modified == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements_dev.txt
+      - name: Executing unit test linter
+        run: |
+          make lint-unit-tests
   trlc:
     name: TRLC
     needs: changes
@@ -104,7 +118,7 @@ jobs:
           make trlc
   test:
     name: TestSuite
-    needs: [changes, lint, lint-system-tests, trlc]
+    needs: [changes, lint-code, lint-system-tests, trlc]
     if: ${{ always() && needs.changes.outputs.only_docu_modified == 'false' }}
     strategy:
       matrix:
@@ -144,7 +158,7 @@ jobs:
           make coverage-unit
   integration-tests:
     name: Integration tests
-    needs: [changes, lint, lint-system-tests, trlc]
+    needs: [changes, lint-code, lint-system-tests, trlc]
     if: ${{ always() && needs.changes.outputs.only_docu_modified == 'false' }}
     runs-on: ubuntu-24.04
     steps:
@@ -184,7 +198,7 @@ jobs:
   failure:
     name: Check all jobs
     needs:
-      - lint
+      - lint-code
       - lint-system-tests
       - trlc
       - test

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ lint-system-tests: style
 		tests-system/lobster-online-report-nogit \
 		tests-system/lobster-report
 
+lint-unit-tests: style
+	@PYTHONPATH=$(SYSTEM_PYTHONPATH) \
+	python3 -m pylint --rcfile=tests-unit/pylint3.cfg \
+		--reports=no \
+		tests-unit
+
 trlc:
 	trlc lobster --error-on-warnings --verify
 

--- a/tests-unit/lobster-codebeamer/test_codebeamer.py
+++ b/tests-unit/lobster-codebeamer/test_codebeamer.py
@@ -1,9 +1,12 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from lobster.tools.codebeamer.codebeamer import (MismatchException, get_query, get_single_item,
-                                                 get_many_items, parse_config_data, to_lobster,
-                                                 import_tagged)
+from lobster.tools.codebeamer.codebeamer import (
+    MismatchException,
+    get_query, get_single_item,
+    get_many_items, parse_config_data, to_lobster,
+    import_tagged,
+)
 
 from lobster.tools.codebeamer.config import AuthenticationConfig, Config
 
@@ -196,7 +199,8 @@ class QueryCodebeamerTest(unittest.TestCase):
             'items': response_items
         }
 
-        expected_result = [to_lobster(self._mock_cb_config, items) for items in response_items]
+        expected_result = [to_lobster(self._mock_cb_config, items)
+                           for items in response_items]
 
         import_tagged_result = import_tagged(self._mock_cb_config, set(item_ids))
 

--- a/tests-unit/lobster-codebeamer/test_codebeamer_schema.py
+++ b/tests-unit/lobster-codebeamer/test_codebeamer_schema.py
@@ -12,14 +12,20 @@ from lobster.tools.codebeamer.config import AuthenticationConfig
 class CbConfigTest(unittest.TestCase):
     def setUp(self):
         self._real_netrc_file=Path(__file__).resolve().parents[0] / "test.netrc"
-        assert isfile(self._real_netrc_file), f"Invalid test setup: netrc file {self._real_netrc_file} does not exist!"
+        self.assertTrue(
+            isfile(self._real_netrc_file),
+            f"Invalid test setup: netrc file {self._real_netrc_file} does not exist!",
+        )
 
     def test_missing_config_file(self):
         """
         Tests that FileNotFoundError is raised if config file is missing.
         """
         missing_config_path = "missing-config.yaml"
-        self.assertFalse(isfile(missing_config_path), "Invalid test setup: file must not exist!")
+        self.assertFalse(
+            isfile(missing_config_path),
+            "Invalid test setup: file must not exist!",
+        )
 
         with self.assertRaises(FileNotFoundError):
             load_config(missing_config_path)
@@ -45,7 +51,10 @@ class CbConfigTest(unittest.TestCase):
                     'schema': 'Requirement',
                 }
             )
-        self.assertIn("Either import_tagged or import_query must be provided!", str(context.exception))
+        self.assertIn(
+            "Either import_tagged or import_query must be provided!",
+            str(context.exception),
+        )
 
     def test_unsupported_config_keys(self):
         with self.assertRaises(KeyError) as context:
@@ -142,7 +151,10 @@ class CbConfigTest(unittest.TestCase):
             root="https://missingmachine.com/cb",
         )
         with self.assertRaises(KeyError) as context:
-            update_authentication_parameters(auth_config, netrc_path=self._real_netrc_file)
+            update_authentication_parameters(
+                auth_config,
+                netrc_path=self._real_netrc_file,
+            )
 
         self.assertIn("Error parsing .netrc file", str(context.exception))
 

--- a/tests-unit/lobster-cpp/test_implementation_builder.py
+++ b/tests-unit/lobster-cpp/test_implementation_builder.py
@@ -1,7 +1,7 @@
 from os import getcwd
-from os.path import abspath, join, expanduser
+from os.path import abspath, join
 import re
-from unittest import TestCase, main
+from unittest import TestCase
 from lobster.location import File_Reference
 from lobster.tools.cpp.implementation_builder import ImplementationBuilder
 
@@ -21,7 +21,8 @@ class ImplementationBuilderTest(TestCase):
 
     def test_get_location_from_abs_path(self):
         impl_builder = ImplementationBuilder()
-        path = join(self._get_os_independent_abspath_start(), "path", "to", "the", "baking soda.NaHCO3")
+        path = join(self._get_os_independent_abspath_start(),
+                    "path", "to", "the", "baking soda.NaHCO3")
         result = impl_builder._get_location(path, 420)
         self.assertEqual(result.filename, path)
         self.assertEqual(result.line, 420)
@@ -33,10 +34,13 @@ class ImplementationBuilderTest(TestCase):
         self.assertEqual(result.filename, abspath("water.H2O"))
         self.assertEqual(result.line, 1)
         self.assertIsNone(result.column)
-    
+
     def test_get_tag(self):
         impl_builder = ImplementationBuilder()
-        for duplicate_file_counter, parent_folder in enumerate(("cake", "pie"), start=1):
+        for duplicate_file_counter, parent_folder in enumerate(
+            ("cake", "pie"),
+            start=1,
+        ):
             FILE = "ingredients.txt"
             path = join(parent_folder, FILE)
             function_names = ["Sodium Chloride (NaCl)", "Glucose (C6H12O6)"]
@@ -44,7 +48,10 @@ class ImplementationBuilderTest(TestCase):
                 with self.subTest(path=path, function_name=function_name):
                     tracing_tag = impl_builder._get_tag(path, function_name, line_nr)
                     self.assertEqual(tracing_tag.namespace, "cpp")
-                    self.assertEqual(tracing_tag.tag, f"{FILE}:{duplicate_file_counter}:{function_name}:{line_nr}")
+                    self.assertEqual(
+                        tracing_tag.tag,
+                        f"{FILE}:{duplicate_file_counter}:{function_name}:{line_nr}",
+                    )
                     self.assertIsNone(tracing_tag.version)
 
     def test_from_match(self):
@@ -64,7 +71,8 @@ class ImplementationBuilderTest(TestCase):
                 if not match:
                     self.fail("Invalid test setup: regex match failed!")
                 if len(match.groups()) != num_groups:
-                    self.fail(f"Invalid test setup: expected {num_groups} groups, got {len(match.groups())}!")
+                    self.fail(f"Invalid test setup: expected {num_groups} groups, "
+                              f"got {len(match.groups())}!")
                 impl = impl_builder.from_match(match)
 
                 self.assertEqual(impl.tag.namespace, "cpp")
@@ -87,8 +95,8 @@ class ImplementationBuilderTest(TestCase):
         if not match:
             self.fail("Invalid test setup: regex match failed!")
         if len(match.groups()) != impl_builder.MIN_NUM_GROUPS:
-            self.fail(f"Invalid test setup: expected {impl_builder.MIN_NUM_GROUPS} groups, "
-                      f"got {len(match.groups())}!")
+            self.fail(f"Invalid test setup: expected {impl_builder.MIN_NUM_GROUPS} "
+                      f"groups, got {len(match.groups())}!")
         with self.assertRaises(ValueError):
             impl_builder.from_match(match)
 

--- a/tests-unit/lobster-cpptest/test_cpptest.py
+++ b/tests-unit/lobster-cpptest/test_cpptest.py
@@ -467,7 +467,11 @@ class LobsterCpptestTests(unittest.TestCase):
             {"suite": "TestMethodsTagTest4", "test_name": "MissingTestMethod", "testmethods": []},
             # Verify that the version tag is correctly parsed
             {"suite": "VersionTagTest", "test_name": "VersionTagTestInOnline", "version": ["1"]},
-            {"suite": "VersionTagTest", "test_name": "MultipleVersionTagTestInOnline", "version": ["1", "42"]},
+            {
+                "suite": "VersionTagTest",
+                "test_name": "MultipleVersionTagTestInOnline",
+                "version": ["1", "42"],
+            },
             {"suite": "VersionTagTest", "test_name": "MoreVersionsThanRequirements", "version": ["12", "70"],
              "req": ["CB-#0815"]},
             {"suite": "VersionTagTest", "test_name": "MoreRequirementsThanVersions", "version": ["28", "28"],

--- a/tests-unit/lobster-online-report-nogit/test_online_report_nogit.py
+++ b/tests-unit/lobster-online-report-nogit/test_online_report_nogit.py
@@ -3,7 +3,10 @@ import os
 from pathlib import Path
 from unittest import TestCase
 from urllib.parse import quote
-from lobster.tools.core.online_report_nogit.online_report_nogit import _file_ref_to_github_ref, RepoInfo
+from lobster.tools.core.online_report_nogit.online_report_nogit import (
+    _file_ref_to_github_ref,
+    RepoInfo,
+)
 from lobster.location import File_Reference, Github_Reference
 
 
@@ -46,12 +49,16 @@ class LobsterOnlineReportNogitTest(TestCase):
                     self.assertEqual(result.commit, repo_info.commit)
                     self.assertEqual(result.line, file_ref.line)
                     escaped_char = quote("ß")
-                    self.assertEqual(result.filename, f"Munich/Dostlerstra{escaped_char}e.werk")
+                    self.assertEqual(
+                        result.filename,
+                        f"Munich/Dostlerstra{escaped_char}e.werk",
+                    )
                     self.assertEqual(
                         result.to_html(),
                         f'<a href="{gh_root}/blob/{repo_info.commit}/' \
-                        f'Munich/Dostlerstra{escaped_char}e.werk#L{file_ref.line}" target="_blank">' \
-                        f'Munich/Dostlerstra{escaped_char}e.werk:{file_ref.line}</a>',
+                        f'Munich/Dostlerstra{escaped_char}e.werk#L{file_ref.line}" ' \
+                        f'target="_blank">Munich/Dostlerstra{escaped_char}e.werk:' \
+                        f'{file_ref.line}</a>',
                     )
 
     def test_real_file_conversion(self):

--- a/tests-unit/lobster-online-report/test_online_report.py
+++ b/tests-unit/lobster-online-report/test_online_report.py
@@ -38,13 +38,19 @@ class LobsterOnlineReportTests(unittest.TestCase):
     def test_print_summary_same_values(self):
         value = "marble"
         actual = get_summary(value, value)
-        self.assertEqual(actual, f"LOBSTER report {value} modified to use online references.")
+        self.assertEqual(
+            actual,
+            f"LOBSTER report {value} modified to use online references.",
+        )
 
     def test_print_summary_different_values(self):
         in_file = "basalt"
         out_file = "granite"
         actual = get_summary(in_file, out_file)
-        self.assertEqual(actual, f"LOBSTER report {out_file} created, using online references.")
+        self.assertEqual(
+            actual,
+            f"LOBSTER report {out_file} created, using online references.",
+        )
 
     def test_commit_hash_for_main_repo(self):
         root = " https://github.com/bmw-software-engineering/lobster"

--- a/tests-unit/lobster-report/test_report.py
+++ b/tests-unit/lobster-report/test_report.py
@@ -9,8 +9,12 @@ class ReportTests(TestCase):
 
         MAX_SUPPORTED_ITEMS = 100000000
 
-        for num_items in list(range(0, 10000)) + [MAX_SUPPORTED_ITEMS / 2, MAX_SUPPORTED_ITEMS]:
-            for ok_items in set((0, 1, 2, int(num_items / 2), max(num_items - 1, 0), num_items)):
+        for num_items in list(range(0, 10000)) \
+            + [MAX_SUPPORTED_ITEMS / 2, MAX_SUPPORTED_ITEMS]:
+            for ok_items in set(
+                (0, 1, 2, int(num_items / 2), max(num_items - 1, 0),
+                 num_items),
+                 ):
                 if num_items < ok_items:
                     continue
 

--- a/tests-unit/lobster-trlc/test_trlc.py
+++ b/tests-unit/lobster-trlc/test_trlc.py
@@ -104,7 +104,11 @@ class LobsterTrlcTests(unittest.TestCase):
 
     @patch("lobster.tools.trlc.trlc.Config_Parser.generate_text")
     @patch("trlc.ast.Record_Object.to_python_dict")
-    def test_generate_lobster_object_trace_true_with_tag_field(self, mock_to_python_dict, mock_generate_text):
+    def test_generate_lobster_object_trace_true_with_tag_field(
+        self,
+        mock_to_python_dict,
+        mock_generate_text,
+    ):
         # Test case 4: When there are tag fields
         tag_field = Mock(spec=ast.Composite_Component)
         tag_field.name = "tag_field"
@@ -136,7 +140,11 @@ class LobsterTrlcTests(unittest.TestCase):
 
     @patch("lobster.tools.trlc.trlc.Config_Parser.generate_text")
     @patch("trlc.ast.Record_Object.to_python_dict")
-    def test_generate_lobster_object_trace_true_with_just_up_field(self, mock_to_python_dict, mock_generate_text):
+    def test_generate_lobster_object_trace_true_with_just_up_field(
+        self,
+        mock_to_python_dict,
+        mock_generate_text,
+    ):
         # Test case 4: When there are just_up field
         just_up_field = Mock(spec=ast.Composite_Component)
         just_up_field.name = "just_up_field"
@@ -173,7 +181,10 @@ class LobsterTrlcTests(unittest.TestCase):
 
         with self.assertRaises(TRLC_Error):
             self.config_parser.generate_text(n_typ, mock_value)
-            self.config_parser.mh.error.assert_called_once_with(ANY, "please define a to_string function for this type in the lobster-trlc configuration file")
+            self.config_parser.mh.error.assert_called_once_with(
+                ANY,
+                "please define a to_string function for this type in the lobster-trlc configuration file",
+            )
 
     @patch("trlc.trlc.ast")
     def test_generate_text_with_non_tuple_type(self, mock_ast):
@@ -208,7 +219,10 @@ class LobsterTrlcTests(unittest.TestCase):
 
         with self.assertRaises(TRLC_Error):
             self.config_parser.generate_text(n_typ, mock_value)
-            self.mh.error.assert_called_with(ANY, f"please define a to_string function that can render {mock_value}")
+            self.mh.error.assert_called_with(
+                ANY,
+                f"please define a to_string function that can render {mock_value}",
+            )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests-unit/pylint3.cfg
+++ b/tests-unit/pylint3.cfg
@@ -1,0 +1,21 @@
+[MASTER]
+persistent=no
+disable=
+ invalid-name,
+ missing-docstring,
+ duplicate-code,
+ too-many-statements,
+ protected-access,
+ no-member,
+ too-many-instance-attributes,
+ too-many-locals,
+ unused-argument,
+ abstract-method,
+ abstract-class-instantiated,
+
+[REPORTS]
+output-format=text
+reports=yes
+
+[FORMAT]
+max-line-length=109

--- a/tests-unit/test_io.py
+++ b/tests-unit/test_io.py
@@ -20,9 +20,26 @@ class LobsterWriteReadTests(unittest.TestCase):
         self.mock_language = "mock_language"
         self.mock_location = create_autospec(Location, instance = True)
         self.tracing_tag = Tracing_Tag(self.mock_namespace, self.mock_tag)
-        self.requirement = Requirement(self.tracing_tag, self.mock_location, self.mock_framework, self.mock_kind, self.mock_name)
-        self.implementation = Implementation(self.tracing_tag, self.mock_location, self.mock_language, self.mock_kind, self.mock_name)
-        self.activity = Activity(self.tracing_tag, self.mock_location, self.mock_framework, self.mock_kind)
+        self.requirement = Requirement(
+            self.tracing_tag,
+            self.mock_location,
+            self.mock_framework,
+            self.mock_kind,
+            self.mock_name,
+        )
+        self.implementation = Implementation(
+            self.tracing_tag,
+            self.mock_location,
+            self.mock_language,
+            self.mock_kind,
+            self.mock_name,
+        )
+        self.activity = Activity(
+            self.tracing_tag,
+            self.mock_location,
+            self.mock_framework,
+            self.mock_kind,
+        )
         self.mh = Message_Handler()
         self.filename = "test.json"
         self.level = "test_level"
@@ -139,12 +156,19 @@ class LobsterWriteReadTests(unittest.TestCase):
             with patch("builtins.open", mock_open(read_data=read_data)):
                 lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
                 self.assertEqual(len(self.items), 1)
-                mock_additional_data_from_json.assert_called_once_with(self.level, self.source_data, mock_data_req["version"])
+                mock_additional_data_from_json.assert_called_once_with(
+                    self.level,
+                    self.source_data, mock_data_req["version"],
+                )
 
     @patch("lobster.items.Item.additional_data_from_json")
     @patch("lobster.items.Tracing_Tag.key")
     @patch("lobster.items.Tracing_Tag.from_json")
-    def test_lobster_read_valid_implementation(self, mock_from_json, mock_key, mock_additional_data_from_json):
+    def test_lobster_read_valid_implementation(
+        self,
+        mock_from_json, mock_key,
+        mock_additional_data_from_json,
+    ):
         mock_key.return_value = "mock_namespace mock_tag"
         mock_from_json.return_value = self.tracing_tag
         self.source_data.update({"location" : {
@@ -165,7 +189,10 @@ class LobsterWriteReadTests(unittest.TestCase):
             with patch("builtins.open", mock_open(read_data=read_data)):
                 lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
                 self.assertEqual(len(self.items), 1)
-                mock_additional_data_from_json.assert_called_once_with(self.level, self.source_data, mock_data_imp["version"])
+                mock_additional_data_from_json.assert_called_once_with(
+                    self.level,
+                    self.source_data, mock_data_imp["version"],
+                )
 
     @patch("lobster.items.Item.additional_data_from_json")
     @patch("lobster.items.Tracing_Tag.key")
@@ -192,24 +219,42 @@ class LobsterWriteReadTests(unittest.TestCase):
             with patch("builtins.open", mock_open(read_data=read_data)):
                 lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
                 self.assertEqual(len(self.items), 1)
-                mock_additional_data_from_json.assert_called_once_with(self.level, self.source_data, mock_data_act["version"])
+                mock_additional_data_from_json.assert_called_once_with(
+                    self.level,
+                    self.source_data, mock_data_act["version"],
+                )
 
     @patch("os.path.isfile", return_value=True)
-    @patch("builtins.open", new_callable=unittest.mock.mock_open, read_data='{"schema": "lobster-req-trace", "version": 4, "generator": "mock_generator"}')
+    @patch(
+        "builtins.open",
+        new_callable=unittest.mock.mock_open,
+        read_data='{"schema": "lobster-req-trace", "version": 4, "generator": "mock_generator"}',
+    )
     def test_lobster_read_missing_data_key(self, mock_file_open, mock_isfile):
         with self.assertRaises(LOBSTER_Error):
             lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
             self.mh.error.assert_called_with(ANY, "required top-level key data not present")
 
     @patch("os.path.isfile", return_value=True)
-    @patch("builtins.open", new_callable=unittest.mock.mock_open, read_data='{"schema": "lobster-req-trace", "version": 5, "generator": "test_gen", "data": []}')
+    @patch(
+        "builtins.open",
+        new_callable=unittest.mock.mock_open,
+        read_data='{"schema": "lobster-req-trace", "version": 5, "generator": "test_gen", "data": []}',
+    )
     def test_lobster_read_unsupported_version(self, mock_file_open, mock_isfile):
         with self.assertRaises(LOBSTER_Error):
             lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
-            self.mh.error.assert_called_with(File_Reference(self.filename), "version 5 for schema lobster-req-trace is not supported")
+            self.mh.error.assert_called_with(
+                File_Reference(self.filename),
+                "version 5 for schema lobster-req-trace is not supported",
+            )
 
     @patch("os.path.isfile", return_value=True)
-    @patch("builtins.open", new_callable=unittest.mock.mock_open, read_data='{"schema": "unknown-schema", "version": 4, "generator": "test_gen", "data": []}')
+    @patch(
+        "builtins.open",
+        new_callable=unittest.mock.mock_open,
+        read_data='{"schema": "unknown-schema", "version": 4, "generator": "test_gen", "data": []}',
+    )
     def test_lobster_read_unknown_schema(self, mock_file_open, mock_isfile):
         with self.assertRaises(LOBSTER_Error):
             lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)

--- a/tests-unit/test_io_signal_duplicate_items.py
+++ b/tests-unit/test_io_signal_duplicate_items.py
@@ -65,7 +65,8 @@ class SignalDuplicateItemsTest(TestCase):
             self.assertEqual(
                 call.kwargs.get("message"),
                 f"duplicate definition of {duplicated_key}, "
-                f"previously defined at {self._items[duplicated_key].location.to_string()}",
+                f"previously defined at "
+                f"{self._items[duplicated_key].location.to_string()}",
             )
             self.assertIs(duplicate_items[i].location, call.kwargs.get("location"))
 

--- a/tests-unit/test_items.py
+++ b/tests-unit/test_items.py
@@ -17,8 +17,22 @@ class ItemsTests(unittest.TestCase):
         self.mock_location = create_autospec(Location, instance=True)
         self.tracing_tag = Tracing_Tag(self.mock_namespace, self.mock_tag)
         self.item = Item(self.tracing_tag, self.mock_location)
-        self.requirement = Requirement(self.tracing_tag, self.mock_location, self.mock_framework,self. mock_kind, self.mock_name, self.mock_text, self.mock_status)
-        self.implementation = Implementation(self.tracing_tag, self.mock_location, self.mock_language, self.mock_kind, self.mock_name)
+        self.requirement = Requirement(
+            self.tracing_tag,
+            self.mock_location,
+            self.mock_framework,
+            self. mock_kind,
+            self.mock_name,
+            self.mock_text,
+            self.mock_status,
+        )
+        self.implementation = Implementation(
+            self.tracing_tag,
+            self.mock_location,
+            self.mock_language,
+            self.mock_kind,
+            self.mock_name,
+        )
         self.activity = Activity(self.tracing_tag, self.mock_location, self.mock_framework, self.mock_kind)
 
     def set_location_data(self, location_type):

--- a/tests-unit/test_location.py
+++ b/tests-unit/test_location.py
@@ -17,7 +17,8 @@ class CodebeamerReferenceTests(TestCase):
                         name=name,
                     )
                     version_addon = f"?version={version}" if version else ""
-                    expected_html = f'<a href="{self._CB_ROOT}/issue/{cb_ref.item}{version_addon}" target="_blank">{cb_ref.to_string()}</a>'
+                    expected_html = f'<a href="{self._CB_ROOT}/issue/{cb_ref.item}' \
+                        f'{version_addon}" target="_blank">{cb_ref.to_string()}</a>'
                     self.assertEqual(expected_html, cb_ref.to_html())
 
     def test_codebeamer_reference_to_string(self):

--- a/tests-unit/test_meta_data_tool_base.py
+++ b/tests-unit/test_meta_data_tool_base.py
@@ -10,7 +10,11 @@ class CherryPineappleTool(MetaDataToolBase):
 
 class MetaDataToolBaseTest(TestCase):
     def setUp(self):
-        self.tool = CherryPineappleTool(name="Knorrstraße", description="A test tool", official=True)
+        self.tool = CherryPineappleTool(
+            name="Knorrstraße",
+            description="A test tool",
+            official=True,
+        )
 
     def test_name(self):
         self.assertEqual(self.tool.name, "lobster-Knorrstraße")

--- a/tests-unit/test_tool.py
+++ b/tests-unit/test_tool.py
@@ -42,7 +42,8 @@ class TestLOBSTER_Tool(unittest.TestCase):
     def test_load_yaml_config_missing_file(self):
         with self.assertRaises(SystemExit) as context:
             self.tool.load_yaml_config("non_existent.yaml")
-        self.assertEqual(str(context.exception), "Error: Config file 'non_existent.yaml' not found.")
+        self.assertEqual(str(context.exception),
+                         "Error: Config file 'non_existent.yaml' not found.")
 
     def test_process_common_options_output_exits_not_file(self):
         with TemporaryDirectory() as temp_dir:
@@ -55,12 +56,20 @@ class TestLOBSTER_Tool(unittest.TestCase):
             with  NamedTemporaryFile("w", delete=False) as temp:
                 temp_path = temp.name
 
-        options = argparse.Namespace(out=None, inputs=[temp_path], inputs_from_file=None)
+        options = argparse.Namespace(
+            out=None,
+            inputs=[temp_path],
+            inputs_from_file=None,
+        )
         work_list = self.tool.process_common_options(options)
         self.assertEqual(work_list, [temp_path])
 
     def test_process_common_options_invalid_inputs(self):
-        options = argparse.Namespace(out=None, inputs=["invalid.txt"], inputs_from_file=None)
+        options = argparse.Namespace(
+            out=None,
+            inputs=["invalid.txt"],
+            inputs_from_file=None,
+        )
         with self.assertRaises(SystemExit):
             self.tool.process_common_options(options)
 


### PR DESCRIPTION
A lot of pylint error types have been disabled.
It is too much effort to fix all pylint findings at once.
The `max-line-length` has been set to 109 instead of 88 as elsewhere.