### PR TITLE
Check output of `lobster-ci-report` in integration test

### DIFF
--- a/tests-integration/projects/basic/.gitignore
+++ b/tests-integration/projects/basic/.gitignore
@@ -1,10 +1,4 @@
-cppcode.lobster
-mcode.lobster
+!*reference_output.lobster
+ci_report.log
 mh_trace.json
-gtests.lobster
-mtests.lobster
-report.lobster
-software-requirements.lobster
 lobster_report.html
-pycode.lobster
-json.lobster

--- a/tests-integration/projects/basic/Makefile
+++ b/tests-integration/projects/basic/Makefile
@@ -8,7 +8,8 @@ CLANG_TIDY:=$(LOBSTER_ROOT)/../llvm-project/build/bin/clang-tidy
 
 THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
-REFERENCE_OUTPUT:='report.reference_output'
+REFERENCE_OUTPUT:='report.reference_output.lobster'
+REFERENCE_OUTPUT_CI:='ci_report.reference_output.log'
 PYTHON = python3
 UPDATE_GIT_HASHES_SCRIPT:='../../../tests-system/tests_utils/update_online_json_with_hashes.py'
 
@@ -18,7 +19,9 @@ html_report.html: cppcode.lobster gtests.lobster mcode.lobster system-requiremen
 	$(PYTHON) $(UPDATE_GIT_HASHES_SCRIPT) $(REFERENCE_OUTPUT)
 	@if diff report.lobster $(REFERENCE_OUTPUT); then echo '✅ Files are identical!'; else { echo '❌ ERROR: Files are different!'; exit 1; }; fi
 	@bash -c "lobster-html-report && echo '✅ lobster-html-report succeeded!' || { echo '❌ ERROR: lobster-html-report failed!'; exit 1; }"
-	@bash -c "lobster-ci-report | tee ci_report.reference_output && echo '✅ lobster-ci-report succeeded!' || { echo '❌ ERROR: lobster-ci-report failed!'; exit 1; }"
+	@bash -c "lobster-ci-report | tee ci_report.log && echo '✅ lobster-ci-report succeeded!' || { echo '❌ ERROR: lobster-ci-report failed!'; exit 1; }"
+	@if diff ci_report.log $(REFERENCE_OUTPUT_CI); then echo '✅ lobster-ci-report log file matches expectation!'; else { echo '❌ ERROR: lobster-ci-report log file does not match expectation!'; exit 1; }; fi
+	rm ci_report.log
 
 cppcode.lobster: foo.h foo.cpp
 	@lobster-cpp foo.cpp foo.h \

--- a/tests-integration/projects/basic/Makefile
+++ b/tests-integration/projects/basic/Makefile
@@ -9,6 +9,7 @@ CLANG_TIDY:=$(LOBSTER_ROOT)/../llvm-project/build/bin/clang-tidy
 THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
 REFERENCE_OUTPUT:='report.reference_output.lobster'
+REFERENCE_OUTPUT_WITH_HASH := report.reference_output_with_hash.lobster
 REFERENCE_OUTPUT_CI:='ci_report.reference_output.log'
 PYTHON = python3
 UPDATE_GIT_HASHES_SCRIPT:='../../../tests-system/tests_utils/update_online_json_with_hashes.py'
@@ -16,8 +17,9 @@ UPDATE_GIT_HASHES_SCRIPT:='../../../tests-system/tests_utils/update_online_json_
 html_report.html: cppcode.lobster gtests.lobster mcode.lobster system-requirements.lobster software-requirements.lobster lobster.conf pycode.lobster json.lobster
 	@bash -c "lobster-report && echo '✅ lobster-report succeeded!' || { echo '❌ ERROR: lobster-report failed!'; exit 1; }"
 	@bash -c "lobster-online-report && echo '✅ lobster-online-report succeeded!' || { echo '❌ ERROR: lobster-online-report failed!'; exit 1; }"
-	$(PYTHON) $(UPDATE_GIT_HASHES_SCRIPT) $(REFERENCE_OUTPUT)
-	@if diff report.lobster $(REFERENCE_OUTPUT); then echo '✅ Files are identical!'; else { echo '❌ ERROR: Files are different!'; exit 1; }; fi
+	$(PYTHON) $(UPDATE_GIT_HASHES_SCRIPT) $(REFERENCE_OUTPUT) $(REFERENCE_OUTPUT_WITH_HASH)
+	@if diff report.lobster $(REFERENCE_OUTPUT_WITH_HASH); then echo '✅ Files are identical!'; else { echo '❌ ERROR: Files are different!'; exit 1; }; fi
+	rm $(REFERENCE_OUTPUT_WITH_HASH)
 	@bash -c "lobster-html-report && echo '✅ lobster-html-report succeeded!' || { echo '❌ ERROR: lobster-html-report failed!'; exit 1; }"
 	@bash -c "lobster-ci-report | tee ci_report.log && echo '✅ lobster-ci-report succeeded!' || { echo '❌ ERROR: lobster-ci-report failed!'; exit 1; }"
 	@if diff ci_report.log $(REFERENCE_OUTPUT_CI); then echo '✅ lobster-ci-report log file matches expectation!'; else { echo '❌ ERROR: lobster-ci-report log file does not match expectation!'; exit 1; }; fi

--- a/tests-integration/projects/basic/ci_report
+++ b/tests-integration/projects/basic/ci_report
@@ -1,6 +1,0 @@
-tests/projects/basic/foo.cpp:9: lobster error: missing up reference
-tests/projects/basic/foo.cpp:14: lobster error: unknown tracing target req example.doesnt_exist
-tests/projects/basic/foo.cpp:14: lobster error: missing up reference
-cb item 666 'LOBSTER demo': lobster error: status is Potato, expected Valid
-tests/projects/basic/potato.trlc:21: lobster error: missing reference to Verification Test
-tests/projects/basic/potato.trlc:9: lobster error: missing reference to Code

--- a/tests-integration/projects/basic/ci_report.reference_output.log
+++ b/tests-integration/projects/basic/ci_report.reference_output.log
@@ -2,7 +2,6 @@ tests-integration/projects/basic/foo.cpp:9: lobster error: missing up reference
 tests-integration/projects/basic/foo.cpp:14: lobster error: unknown tracing target req example.doesnt_exist
 tests-integration/projects/basic/foo.cpp:14: lobster error: missing up reference
 tests-integration/projects/basic/exclusive_or.slx:1: lobster error: missing up reference
-cb item 666 'LOBSTER demo': lobster error: status is Potato, expected Valid
 tests-integration/projects/basic/potato.trlc:39: lobster error: missing reference to Code
 tests-integration/projects/basic/potato.trlc:39: lobster error: missing reference to Verification Test
 tests-integration/projects/basic/potato.trlc:22: lobster error: missing up reference

--- a/tests-integration/projects/basic/report.reference_output.lobster
+++ b/tests-integration/projects/basic/report.reference_output.lobster
@@ -46,7 +46,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/potato.trlc",
             "line": 3
           },
@@ -73,7 +73,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/potato.trlc",
             "line": 9
           },
@@ -103,7 +103,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/potato.trlc",
             "line": 15
           },
@@ -131,7 +131,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/potato.trlc",
             "line": 22
           },
@@ -160,7 +160,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/potato.trlc",
             "line": 27
           },
@@ -184,7 +184,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/potato.trlc",
             "line": 39
           },
@@ -219,7 +219,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/foo.cpp",
             "line": 3
           },
@@ -241,7 +241,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/foo.cpp",
             "line": 9
           },
@@ -261,7 +261,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/foo.cpp",
             "line": 14
           },
@@ -282,7 +282,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/nand.m",
             "line": 1
           },
@@ -304,7 +304,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/exclusive_or.slx",
             "line": 1
           },
@@ -324,7 +324,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/exclusive_or.slx",
             "line": null
           },
@@ -344,7 +344,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/exclusive_or.slx",
             "line": null
           },
@@ -366,7 +366,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/nor.py",
             "line": 5
           },
@@ -386,7 +386,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/nor.py",
             "line": 13
           },
@@ -408,7 +408,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/nor.py",
             "line": 17
           },
@@ -437,7 +437,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/test.cpp",
             "line": 7
           },
@@ -460,7 +460,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/nand_test.m",
             "line": 3
           },
@@ -483,7 +483,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/example.json",
             "line": null
           },
@@ -506,7 +506,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/example.json",
             "line": null
           },
@@ -529,7 +529,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "650df2804c918a8e5c773dd1bf1cc26b9f6a2b75",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/basic/example.json",
             "line": null
           },

--- a/tests-integration/projects/cpp-focus/.gitignore
+++ b/tests-integration/projects/cpp-focus/.gitignore
@@ -1,5 +1,3 @@
-cppcode.lobster
-gtests.lobster
-report.lobster
-software-requirements.lobster
+!*reference_output.lobster
+ci_report.log
 lobster_report.html

--- a/tests-integration/projects/cpp-focus/Makefile
+++ b/tests-integration/projects/cpp-focus/Makefile
@@ -9,6 +9,7 @@ CLANG_TIDY:=$(LOBSTER_ROOT)/../llvm-project/build/bin/clang-tidy
 THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
 REFERENCE_OUTPUT:='report.reference_output.lobster'
+REFERENCE_OUTPUT_WITH_HASH := report.reference_output_with_hash.lobster
 REFERENCE_OUTPUT_CI:='ci_report.reference_output.log'
 PYTHON = python3
 UPDATE_GIT_HASHES_SCRIPT:='../../../tests-system/tests_utils/update_online_json_with_hashes.py'
@@ -16,7 +17,9 @@ UPDATE_GIT_HASHES_SCRIPT:='../../../tests-system/tests_utils/update_online_json_
 html_report.html: cppcode.lobster gtests.lobster software-requirements.lobster lobster.conf
 	@bash -c "lobster-report && echo '$(THIS_TEST) ✅ lobster-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-report failed!'; exit 1; }"
 	@bash -c "lobster-online-report && echo '$(THIS_TEST) ✅ lobster-online-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-online-report failed!'; exit 1; }"
-	$(PYTHON) $(UPDATE_GIT_HASHES_SCRIPT) $(REFERENCE_OUTPUT)
+	$(PYTHON) $(UPDATE_GIT_HASHES_SCRIPT) $(REFERENCE_OUTPUT) $(REFERENCE_OUTPUT_WITH_HASH)
+	@if diff report.lobster $(REFERENCE_OUTPUT_WITH_HASH); then echo '✅ Files are identical!'; else { echo '❌ ERROR: Files are different!'; exit 1; }; fi
+	rm $(REFERENCE_OUTPUT_WITH_HASH)
 	@bash -c "lobster-html-report && echo '$(THIS_TEST) ✅ lobster-html-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-html-report failed!'; exit 1; }"
 	@bash -c "lobster-ci-report | tee ci_report.log && echo '✅ lobster-ci-report succeeded!' || { echo '❌ ERROR: lobster-ci-report failed!'; exit 1; }"
 	@if diff ci_report.log $(REFERENCE_OUTPUT_CI); then echo '✅ lobster-ci-report log file matches expectation!'; else { echo '❌ ERROR: lobster-ci-report log file does not match expectation!'; exit 1; }; fi

--- a/tests-integration/projects/cpp-focus/Makefile
+++ b/tests-integration/projects/cpp-focus/Makefile
@@ -8,16 +8,19 @@ CLANG_TIDY:=$(LOBSTER_ROOT)/../llvm-project/build/bin/clang-tidy
 
 THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
-REFERENCE_OUTPUT:='report1.reference_output'
+REFERENCE_OUTPUT:='report.reference_output.lobster'
+REFERENCE_OUTPUT_CI:='ci_report.reference_output.log'
 PYTHON = python3
 UPDATE_GIT_HASHES_SCRIPT:='../../../tests-system/tests_utils/update_online_json_with_hashes.py'
 
 html_report.html: cppcode.lobster gtests.lobster software-requirements.lobster lobster.conf
-	@bash -c "lobster-report --out=whatever.lobster && echo '$(THIS_TEST) ✅ lobster-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-report failed!'; exit 1; }"
-	@bash -c "lobster-online-report whatever.lobster && echo '$(THIS_TEST) ✅ lobster-online-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-online-report failed!'; exit 1; }"
+	@bash -c "lobster-report && echo '$(THIS_TEST) ✅ lobster-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-report failed!'; exit 1; }"
+	@bash -c "lobster-online-report && echo '$(THIS_TEST) ✅ lobster-online-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-online-report failed!'; exit 1; }"
 	$(PYTHON) $(UPDATE_GIT_HASHES_SCRIPT) $(REFERENCE_OUTPUT)
-	@bash -c "lobster-html-report whatever.lobster && echo '$(THIS_TEST) ✅ lobster-html-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-html-report failed!'; exit 1; }"
-	@if diff whatever.lobster $(REFERENCE_OUTPUT); then echo '$(THIS_TEST) ✅ Files are identical!'; else { echo '$(THIS_TEST) ❌ ERROR: generated file whatever.lobster is not matching the expectation!'; exit 1; }; fi
+	@bash -c "lobster-html-report && echo '$(THIS_TEST) ✅ lobster-html-report succeeded!' || { echo '$(THIS_TEST) ❌ ERROR: lobster-html-report failed!'; exit 1; }"
+	@bash -c "lobster-ci-report | tee ci_report.log && echo '✅ lobster-ci-report succeeded!' || { echo '❌ ERROR: lobster-ci-report failed!'; exit 1; }"
+	@if diff ci_report.log $(REFERENCE_OUTPUT_CI); then echo '✅ lobster-ci-report log file matches expectation!'; else { echo '❌ ERROR: lobster-ci-report log file does not match expectation!'; exit 1; }; fi
+	rm ci_report.log
 
 cppcode.lobster: fruit.h fruit.cpp
 	@lobster-cpp fruit.cpp fruit.h \

--- a/tests-integration/projects/cpp-focus/ci_report.reference_output.log
+++ b/tests-integration/projects/cpp-focus/ci_report.reference_output.log
@@ -1,0 +1,28 @@
+tests-integration/projects/cpp-focus/fruit.cpp:155: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:87: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:97: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:52: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:35: lobster error: unknown tracing target req cd-456
+tests-integration/projects/cpp-focus/fruit.cpp:35: lobster error: unknown tracing target req ab-123
+tests-integration/projects/cpp-focus/fruit.cpp:35: lobster error: unknown tracing target req 89
+tests-integration/projects/cpp-focus/fruit.cpp:35: lobster error: unknown tracing target req 456
+tests-integration/projects/cpp-focus/fruit.cpp:35: lobster error: unknown tracing target req 123
+tests-integration/projects/cpp-focus/fruit.cpp:35: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:62: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:42: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:47: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:67: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:57: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:72: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.cpp:92: lobster error: missing up reference
+tests-integration/projects/cpp-focus/fruit.trlc:3: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:8: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:28: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:50: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:65: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:70: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:75: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:13: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:18: lobster error: missing reference to Verification Test
+tests-integration/projects/cpp-focus/fruit.trlc:38: lobster error: missing reference to Code
+tests-integration/projects/cpp-focus/fruit.trlc:33: lobster error: missing reference to Verification Test

--- a/tests-integration/projects/cpp-focus/report.reference_output.lobster
+++ b/tests-integration/projects/cpp-focus/report.reference_output.lobster
@@ -12,7 +12,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 3
           },
@@ -38,7 +38,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 8
           },
@@ -64,7 +64,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 13
           },
@@ -90,7 +90,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 18
           },
@@ -116,7 +116,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 23
           },
@@ -142,7 +142,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 28
           },
@@ -168,7 +168,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 33
           },
@@ -194,7 +194,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 38
           },
@@ -220,7 +220,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 45
           },
@@ -245,7 +245,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 50
           },
@@ -271,7 +271,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 55
           },
@@ -296,7 +296,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 60
           },
@@ -321,7 +321,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 65
           },
@@ -347,7 +347,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 70
           },
@@ -373,7 +373,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.trlc",
             "line": 75
           },
@@ -406,7 +406,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 16
           },
@@ -429,7 +429,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 23
           },
@@ -455,7 +455,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 35
           },
@@ -480,7 +480,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 42
           },
@@ -500,7 +500,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 47
           },
@@ -520,7 +520,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 52
           },
@@ -540,7 +540,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 57
           },
@@ -560,7 +560,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 62
           },
@@ -580,7 +580,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 67
           },
@@ -600,7 +600,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 72
           },
@@ -620,7 +620,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 87
           },
@@ -640,7 +640,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 92
           },
@@ -660,7 +660,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 97
           },
@@ -680,7 +680,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 101
           },
@@ -703,7 +703,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 108
           },
@@ -726,7 +726,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 122
           },
@@ -748,7 +748,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 131
           },
@@ -770,7 +770,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 142
           },
@@ -792,7 +792,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit.cpp",
             "line": 155
           },
@@ -819,7 +819,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit_test.cpp",
             "line": 9
           },
@@ -842,7 +842,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit_test.cpp",
             "line": 17
           },
@@ -866,7 +866,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit_test.cpp",
             "line": 29
           },
@@ -889,7 +889,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit_test.cpp",
             "line": 47
           },
@@ -912,7 +912,7 @@
           "location": {
             "kind": "github",
             "gh_root": "https://github.com/bmw-software-engineering/lobster",
-            "commit": "this string will be replaced by the current commit during execution",
+            "commit": "this string will be replaced by the current commit during test execution",
             "file": "tests-integration/projects/cpp-focus/fruit_test.cpp",
             "line": 63
           },

--- a/tests-system/tests_utils/update_online_json_with_hashes.py
+++ b/tests-system/tests_utils/update_online_json_with_hashes.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 
-def update_json(filename, expected_location=None):
+def update_json(filename, expected_location=None, out=None):
     # Load the JSON data from the file
     with open(filename, 'r') as file:
         data = json.load(file)
@@ -19,13 +19,15 @@ def update_json(filename, expected_location=None):
                 if expected_location:
                     location['file'] = expected_location
 
-    # Save the updated JSON data back to the same file
-    with open(filename, 'w') as fd:
+    # Save the updated JSON data into the output file
+    if not out:
+        out = filename
+    with open(out, 'w') as fd:
         json.dump(data, fd, indent=2)
         fd.write("\n")
 
-    print(f"JSON data updated and saved back to '{filename}'.")
+    print(f"JSON data updated and saved to '{out}'.")
 
 
 if __name__ == "__main__":
-    update_json(sys.argv[1])
+    update_json(sys.argv[1], out=sys.argv[2])


### PR DESCRIPTION
The `Makefile` for all the integration tests call `lobster-ci-report`, but never compare its output against an expectation.

This commit fixes the problem in the "basic" and "cpp-focus" integration tests. Other tests are not fixed.

Also adjusted file endings to be `*.lobster`, if they are LOBSTER files.

Also updated the script which replaces the placeholder in a LOBSTER file with the current commit hash such that a new file is created instead of overwriting the existing file.