### PR TITLE
Bump version to 0.13.3-dev after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Changelog
 
 
+### 0.13.3-dev
+
+
+
 ### 0.13.2
 
 * `lobster-html-report`

--- a/lobster/version.py
+++ b/lobster/version.py
@@ -17,8 +17,8 @@
 # License along with this program. If not, see
 # <https://www.gnu.org/licenses/>.
 
-VERSION_TUPLE = (0, 13, 2)
-VERSION_SUFFIX = ""
+VERSION_TUPLE = (0, 13, 3)
+VERSION_SUFFIX = "dev"
 
 LOBSTER_VERSION = ".".join(str(x) for x in VERSION_TUPLE) + (
     "-%s" % VERSION_SUFFIX if VERSION_SUFFIX else ""


### PR DESCRIPTION
Bump LOBSTER versions to 0.13.3-dev after release in `CHANGELOG.md` and `version.py`.