### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-13
             brew: "/usr/local"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@
 
 ### 0.13.3-dev
 
+* Support Python 3.13
+  The test matrix has been extended to include Python 3.13.
+  This modification requires at least TRLC v2.0.2, because earlier versions were
+  restricted to Python 3.12 or lower.
 
+* `lobster-trlc`:
+  - Added support for Python 3.13.
+    Then at least least the Python package `trlc` v2.0.2 is required,
+    otherwise at least v2.0.1.
+    The restriction comes from the fact that `trlc` v2.0.1 is restricted to
+    Python < 3.13.
+  - Fix wrong dependency information in packaging instructions for wheel file
+    (`setup.py`), as described above.
 
 ### 0.13.2
 

--- a/packages/lobster-tool-trlc/setup.py
+++ b/packages/lobster-tool-trlc/setup.py
@@ -46,7 +46,10 @@ setuptools.setup(
     project_urls=project_urls,
     license="GNU Affero General Public License v3",
     packages=["lobster.tools.trlc"],
-    install_requires=["trlc>=1.2.2", "bmw-lobster-core>=%s" % version.LOBSTER_VERSION],
+    install_requires=[
+        "trlc>=2.0.1",
+        f"bmw-lobster-core>={version.LOBSTER_VERSION}",
+    ],
     python_requires=">=3.7, <4",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Include Python 3.13 in the test matrix.
This modification requires TRLC 2.0.2 or higher.