### PR TITLE
Eliminate Mock Server Race Condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,8 @@ system-tests.lobster-%:
 
 # STF is short for System Test Framework
 STF_TRLC_FILES := $(wildcard tests_system/*.trlc)
-STF_PYTHON_FILES := $(filter-out tests_system/test_%.py tests_system/run_tool_tests.py, $(wildcard tests_system/*.py))
+STF_PYTHON_FILES := $(filter-out tests_system/test_%.py tests_system/run_tool_tests.py, $(wildcard tests_system/*.py) tests_system/lobster_codebeamer/mock_server.py tests_system/lobster_codebeamer/mock_server_setup.py)
+STF_OUTPUT_FILE := docs/tracing-stf.html
 
 # This target is used to generate the LOBSTER report for the requirements of the system test framework itself.
 tracing-stf: $(STF_TRLC_FILES)
@@ -249,6 +250,7 @@ tracing-stf: $(STF_TRLC_FILES)
 	lobster-python --out=stf_code.lobster --only-tagged-functions $(STF_PYTHON_FILES)
 	lobster-report --lobster-config=tests_system/stf-lobster.conf --out=stf_report.lobster
 	lobster-online-report stf_report.lobster
-	lobster-html-report stf_report.lobster --out=docs/tracing-stf.html
+	lobster-html-report stf_report.lobster --out=$(STF_OUTPUT_FILE)
+	@echo "✅ STF report generated at $(STF_OUTPUT_FILE)"
 	@echo "Deleting STF *.lobster files..."
 	rm -f stf_system_requirements.lobster stf_software_requirements.lobster stf_code.lobster stf_report.lobster

--- a/lobster/tools/lobster-trlc-software-stf.yaml
+++ b/lobster/tools/lobster-trlc-software-stf.yaml
@@ -1,2 +1,2 @@
 inputs: ['lobster/tools/requirements.rsl', 'tests_system/system_test_framework.trlc']
-trlc_config_file: 'lobster\tools\lobster-trlc-software.conf'
+trlc_config_file: 'lobster/tools/lobster-trlc-software.conf'

--- a/tests_system/lobster_codebeamer/test_extract_requirements.py
+++ b/tests_system/lobster_codebeamer/test_extract_requirements.py
@@ -3,7 +3,7 @@ from flask import Response
 from .lobster_codebeamer_system_test_case_base import (
     LobsterCodebeamerSystemTestCaseBase)
 from .lobster_codebeamer_asserter import LobsterCodebeamerAsserter
-from .mock_server_setup import start_mock_server, get_mock_app
+from .mock_server_setup import get_mock_app
 
 
 class LobsterCodebeamerExtractRequirementsTest(LobsterCodebeamerSystemTestCaseBase):
@@ -11,7 +11,6 @@ class LobsterCodebeamerExtractRequirementsTest(LobsterCodebeamerSystemTestCaseBa
     @classmethod
     def setUpClass(cls):
         """Start the mock server once before any tests run."""
-        start_mock_server()
         cls.codebeamer_flask = get_mock_app()
 
     def setUp(self):

--- a/tests_system/lobster_codebeamer/test_lobster_codebeamer.py
+++ b/tests_system/lobster_codebeamer/test_lobster_codebeamer.py
@@ -3,7 +3,7 @@ from flask import Response
 from .lobster_codebeamer_system_test_case_base import (
     LobsterCodebeamerSystemTestCaseBase)
 from ..asserter import Asserter
-from .mock_server_setup import start_mock_server, get_mock_app
+from .mock_server_setup import get_mock_app
 
 
 class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
@@ -13,7 +13,6 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
     @classmethod
     def setUpClass(cls):
         """Start the mock server once before any tests run."""
-        start_mock_server()
         cls.codebeamer_flask = get_mock_app()
 
     def setUp(self):

--- a/tests_system/lobster_codebeamer/test_valid_flow.py
+++ b/tests_system/lobster_codebeamer/test_valid_flow.py
@@ -3,7 +3,7 @@ from flask import Response
 from .lobster_codebeamer_system_test_case_base import (
     LobsterCodebeamerSystemTestCaseBase)
 from .lobster_codebeamer_asserter import LobsterCodebeamerAsserter
-from .mock_server_setup import start_mock_server, get_mock_app
+from .mock_server_setup import get_mock_app
 
 
 class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
@@ -12,7 +12,6 @@ class LobsterCodebeamerTest(LobsterCodebeamerSystemTestCaseBase):
 
     @classmethod
     def setUpClass(cls):
-        start_mock_server()
         cls.codebeamer_flask = get_mock_app()
 
     def setUp(self):

--- a/tests_system/system_test_case_base.py
+++ b/tests_system/system_test_case_base.py
@@ -1,8 +1,12 @@
 from pathlib import Path
+import logging
 import shutil
 from tempfile import TemporaryDirectory
 from typing import List, Optional, Union
 from unittest import TestCase
+
+
+logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(name)s: %(message)s')
 
 
 class SystemTestCaseBase(TestCase):

--- a/tests_system/system_test_framework.trlc
+++ b/tests_system/system_test_framework.trlc
@@ -135,3 +135,52 @@ req.Software_Requirement CWD_Placeholder {
     '''
     derived_from = [Fail_on_Output_File_Mismatch]
 }
+
+section "Codebeamer Mock Server"{
+    req.System_Requirement Codebeamer_Mock_Server_Replies {
+        description = '''
+            The mock server shall be able to respond to requests with predefined responses.
+        '''
+    }
+
+    req.Software_Requirement Codebeamer_Flask_Responses_Setter {
+        description = '''
+            The CodebeamerFlask class shall provide a property
+            which shall allow setting predefined responses for subsequent requests.
+        '''
+        derived_from = [Codebeamer_Mock_Server_Replies]
+    }
+
+    req.Software_Requirement Codebeamer_Flask_Responses_Reset {
+        description = '''
+            The CodebeamerFlask class shall provide a function called 'reset'
+            which resets the predefined responses to an empty list.
+        '''
+        derived_from = [Codebeamer_Mock_Server_Replies]
+    }
+
+    req.System_Requirement Codebeamer_Mock_Server_Startup {
+        description = '''
+            The mock server shall be started before the tests run.
+        '''
+    }
+
+    req.Software_Requirement Codebeamer_Mock_Server_Await_Startup {
+        description = '''
+            The CodebeamerFlask class shall provide a function called 'await_startup_finished'
+            which shall try to connect to the mock server for 10 times until it is ready.
+
+            Note: This way we want to check if the underlying Flask server is ready.
+            The Flask library does not provide a different way to figure it out.
+        '''
+        derived_from = [Codebeamer_Mock_Server_Startup]
+    }
+
+    req.Software_Requirement Use_Await_Startup_Finished {
+        description = '''
+            The function 'get_mock_app' shall return a CodebeamerFlask instance
+            for which 'await_startup_finished' has been called.
+            '''
+        derived_from = [Codebeamer_Mock_Server_Startup]
+    }
+}


### PR DESCRIPTION
The Flask codebeamer mock server is started on a separate thread
during class setup of the `lobster-codebeamer` system tests.
A race condition can occur where the first system test sends a
request to the mock server before it has fully started up, causing
test failures.

To prevent this, we now send test requests to verify the mock
server is responsive before proceeding with system tests. This
ensures reliable test execution by eliminating the startup race
condition.

Additionally set log level to DEBUG in `SystemTestCaseBase`.