### PR TITLE
Update requirements for STF function `update_json`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ system-tests.lobster-%:
 
 # STF is short for System Test Framework
 STF_TRLC_FILES := $(wildcard tests_system/*.trlc)
-STF_PYTHON_FILES := $(filter-out tests_system/test_%.py tests_system/run_tool_tests.py, $(wildcard tests_system/*.py) tests_system/lobster_codebeamer/mock_server.py tests_system/lobster_codebeamer/mock_server_setup.py)
+STF_PYTHON_FILES := $(filter-out tests_system/test_%.py tests_system/run_tool_tests.py, $(wildcard tests_system/*.py) tests_system/lobster_codebeamer/mock_server.py tests_system/lobster_codebeamer/mock_server_setup.py tests_system/tests_utils/update_online_json_with_hashes.py)
 STF_OUTPUT_FILE := docs/tracing-stf.html
 
 # This target is used to generate the LOBSTER report for the requirements of the system test framework itself.

--- a/tests_system/system_test_framework.trlc
+++ b/tests_system/system_test_framework.trlc
@@ -60,8 +60,8 @@ req.Software_Requirement Provide_Virtual_Environment {
 
 req.Software_Requirement Enrich_With_Hash {
     description = '''
-        The test asserter shall provide a function to enrich the LOBSTER file, which
-        represents the expectation value, with the git hash of the current commit hash
+        The function 'update_json' shall enrich a LOBSTER file (which
+        represents the expectation value) with the git hash of the current commit hash
         of the underlying git repository.
     '''
 }

--- a/tests_system/tests_utils/update_online_json_with_hashes.py
+++ b/tests_system/tests_utils/update_online_json_with_hashes.py
@@ -4,17 +4,18 @@ import sys
 
 
 def update_json(filename, expected_location=None, out=None):
+    # lobster-trace: system_test.Enrich_With_Hash
     # Load the JSON data from the file
     with open(filename, 'r') as file:
         data = json.load(file)
+
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
 
     # Traverse the JSON structure and update the 'loc' values
     for level in data['levels']:
         for item in level['items']:
             location = item['location']
             if 'file' in location:
-                commit = subprocess.check_output(
-                    ["git", "rev-parse", "HEAD"]).decode().strip()
                 location['commit'] = commit
                 if expected_location:
                     location['file'] = expected_location


### PR DESCRIPTION
Also improve the implementation of the system test framework helper
script `update_online_json_with_hashes.py`.
Previously it executed `git rev-parse HEAD` for each item in the
JSON file. But the hash will always be the same, because our repository
does not use any submodules. So `git` can be called once, and the result
can be used for all items.