### PR TITLE
Add Type Hierarchy System Test for `lobster-trlc`

### DIFF
--- a/tests_system/lobster_trlc/data/extraction_hierarchy.rsl
+++ b/tests_system/lobster_trlc/data/extraction_hierarchy.rsl
@@ -1,0 +1,7 @@
+package extraction_test
+
+type base_type {
+    description String
+}
+
+type extended_type extends base_type {}

--- a/tests_system/lobster_trlc/data/extraction_hierarchy.trlc
+++ b/tests_system/lobster_trlc/data/extraction_hierarchy.trlc
@@ -1,0 +1,9 @@
+package extraction_test
+
+base_type A {
+    description ="AA"
+}
+
+extended_type B {
+    description ="BB"
+}

--- a/tests_system/lobster_trlc/data/extraction_hierarchy_base_and_extended.conf
+++ b/tests_system/lobster_trlc/data/extraction_hierarchy_base_and_extended.conf
@@ -1,0 +1,3 @@
+extraction_test.base_type {
+  description = description
+}

--- a/tests_system/lobster_trlc/data/extraction_hierarchy_base_and_extended.out.lobster
+++ b/tests_system/lobster_trlc/data/extraction_hierarchy_base_and_extended.out.lobster
@@ -1,0 +1,43 @@
+{
+  "data": [
+    {
+      "tag": "req extraction_test.A",
+      "location": {
+        "kind": "file",
+        "file": "extraction_hierarchy.trlc",
+        "line": 3,
+        "column": 11
+      },
+      "name": "extraction_test.A",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "framework": "TRLC",
+      "kind": "base_type",
+      "text": "AA",
+      "status": null
+    },
+    {
+      "tag": "req extraction_test.B",
+      "location": {
+        "kind": "file",
+        "file": "extraction_hierarchy.trlc",
+        "line": 7,
+        "column": 15
+      },
+      "name": "extraction_test.B",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "framework": "TRLC",
+      "kind": "extended_type",
+      "text": "BB",
+      "status": null
+    }
+  ],
+  "generator": "lobster-trlc",
+  "schema": "lobster-req-trace",
+  "version": 4
+}

--- a/tests_system/lobster_trlc/data/extraction_hierarchy_extended_only.conf
+++ b/tests_system/lobster_trlc/data/extraction_hierarchy_extended_only.conf
@@ -1,0 +1,3 @@
+extraction_test.extended_type {
+  description = description
+}

--- a/tests_system/lobster_trlc/data/extraction_hierarchy_extended_only.out.lobster
+++ b/tests_system/lobster_trlc/data/extraction_hierarchy_extended_only.out.lobster
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "tag": "req extraction_test.B",
+      "location": {
+        "kind": "file",
+        "file": "extraction_hierarchy.trlc",
+        "line": 7,
+        "column": 15
+      },
+      "name": "extraction_test.B",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "framework": "TRLC",
+      "kind": "extended_type",
+      "text": "BB",
+      "status": null
+    }
+  ],
+  "generator": "lobster-trlc",
+  "schema": "lobster-req-trace",
+  "version": 4
+}

--- a/tests_system/lobster_trlc/test_extraction.py
+++ b/tests_system/lobster_trlc/test_extraction.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from .lobster_system_test_case_base import LobsterTrlcSystemTestCaseBase
+from ..asserter import Asserter
+
+
+class InputFromFilesTest(LobsterTrlcSystemTestCaseBase):
+    def test_base_and_extended(self):
+        @dataclass
+        class TestSetup:
+            name: str
+            num_expected_items: int
+
+        test_setups = [
+            TestSetup(
+                name="base_and_extended",
+                num_expected_items=2,
+            ),
+            TestSetup(
+                name="extended_only",
+                num_expected_items=1,
+            ),
+        ]
+
+        for setup in test_setups:
+            with self.subTest(setup=setup.name):
+                test_runner = self.create_test_runner()
+                test_runner.declare_trlc_config_file(
+                    self._data_directory / f"extraction_hierarchy_{setup.name}.conf",
+                )
+                out_file = f"extraction_hierarchy_{setup.name}.out.lobster"
+                test_runner.cmd_args.out = out_file
+                test_runner.declare_output_file(self._data_directory / out_file)
+                test_runner.config_file_data.inputs = [
+                    "extraction_hierarchy.trlc",
+                    "extraction_hierarchy.rsl",
+                ]
+                for file in test_runner.config_file_data.inputs:
+                    test_runner.copy_file_to_working_directory(
+                        self._data_directory / file,
+                    )
+                completed_process = test_runner.run_tool_test()
+                asserter = Asserter(self, completed_process, test_runner)
+                asserter.assertNoStdErrText()
+                asserter.assertStdOutText(
+                    f"lobster-trlc: successfully wrote {setup.num_expected_items} "
+                    f"items to {out_file}\n",
+                )
+                asserter.assertExitCode(0)
+                asserter.assertOutputFiles()


### PR DESCRIPTION
Add a system test that verifies the behavior of `lobster-trlc` with respect to extended TRLC types.

In the test input data two TRLC record types exist:
- a base type
- and a type which extends the base type

Depending on the configuration of `lobster-trlc` either all TRLC record objects of both types shall be converted to LOBSTER objects, or only the extended type.

Converting only the base type is not supported.