### PR TITLE
Fix TRLC Dependency Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@
   - The tool now accepts exactly four configuration attributes in config file: `output_file`, `codebeamer_url`, `kind` and `files`.
   - Note: The tool now generates only one output file per execution.
 
+* `bmw-lobster-tool-trlc` Python Package:
+  - Fix wrong dependency information in packaging instructions for wheel file (`setup.py`).
+    Only the package [bmw-lobster-tool-trlc](https://pypi.org/project/bmw-lobster-tool-trlc/)
+    was affected, not the package
+    [bmw-lobster-monolithic](https://pypi.org/project/bmw-lobster-monolithic/), which also
+    includes the tool `lobster-trlc`.
+    The minimum required version of [TRLC](https://pypi.org/project/trlc/) is v2.0.1, not v1.2.2.
+    ```
+    > pip install bmw-lobster-tool-trlc
+    ```
+    will now correctly require `trlc>=2.0.1`.  
+
 ### 0.13.2
 
 * `lobster-html-report`

--- a/packages/lobster-tool-trlc/setup.py
+++ b/packages/lobster-tool-trlc/setup.py
@@ -46,7 +46,10 @@ setuptools.setup(
     project_urls=project_urls,
     license="GNU Affero General Public License v3",
     packages=["lobster.tools.trlc"],
-    install_requires=["trlc>=1.2.2", "bmw-lobster-core>=%s" % version.LOBSTER_VERSION],
+    install_requires=[
+        "trlc>=2.0.1",
+        f"bmw-lobster-core>={version.LOBSTER_VERSION}",
+    ],
     python_requires=">=3.7, <4",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
`lobster-trlc` requires at least version 2.0.1, not 1.2.2