### PR TITLE
Fix `Makefile` of Integration Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ integration-tests: packages
 	(cd tests_integration/projects/coverage_mix; make)
 	(cd tests_integration/projects/coverage_zero; make)
 	(cd tests_integration/projects/cpp_focus; make)
-	rm -f MODULE.bazel MODULE.bazel.lock
 
 codebeamer-pem:
 	@echo "🔐 Generating cert.pem and key.pem for codebeamer system tests..."

--- a/tests_integration/projects/coverage/Makefile
+++ b/tests_integration/projects/coverage/Makefile
@@ -7,7 +7,7 @@ THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
 REFERENCE_OUTPUT:=report.reference_output
 
-html_report.html: softreq.lobster sysreq.lobster lobster.conf trlc-softreq.conf trlc-sysreq.conf
+html_report.html: softreq.lobster sysreq.lobster lobster.conf
 	@lobster-report
 	@if diff report.lobster $(REFERENCE_OUTPUT); then \
 	    echo "Files are identical"; \

--- a/tests_integration/projects/coverage/trlc-softreq.conf
+++ b/tests_integration/projects/coverage/trlc-softreq.conf
@@ -1,4 +1,0 @@
-coverage_example.Software_Requirement {
-  description = text
-  tags "req"  = derived_from
-}

--- a/tests_integration/projects/coverage/trlc-sysreq.conf
+++ b/tests_integration/projects/coverage/trlc-sysreq.conf
@@ -1,3 +1,0 @@
-coverage_example.System_Requirement {
-  description = text
-}

--- a/tests_integration/projects/coverage_half/Makefile
+++ b/tests_integration/projects/coverage_half/Makefile
@@ -7,7 +7,7 @@ THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
 REFERENCE_OUTPUT:=report.reference_output
 
-html_report.html: softreq.lobster sysreq.lobster lobster.conf trlc-softreq.conf trlc-sysreq.conf
+html_report.html: softreq.lobster sysreq.lobster lobster.conf
 	@lobster-report
 	@if diff report.lobster $(REFERENCE_OUTPUT); then \
 	    echo "Files are identical"; \

--- a/tests_integration/projects/coverage_half/trlc-softreq.conf
+++ b/tests_integration/projects/coverage_half/trlc-softreq.conf
@@ -1,4 +1,0 @@
-coverage_half.Software_Requirement {
-  description = text
-  tags "req"  = derived_from
-}

--- a/tests_integration/projects/coverage_half/trlc-sysreq.conf
+++ b/tests_integration/projects/coverage_half/trlc-sysreq.conf
@@ -1,3 +1,0 @@
-coverage_half.System_Requirement {
-  description = text
-}

--- a/tests_integration/projects/coverage_mix/Makefile
+++ b/tests_integration/projects/coverage_mix/Makefile
@@ -7,7 +7,7 @@ THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
 REFERENCE_OUTPUT:=report.reference_output
 
-html_report.html: req_a.lobster req_b.lobster test_a.lobster lobster.conf trlc_req_a.conf trlc_req_b.conf trlc_test_spec.conf
+html_report.html: req_a.lobster req_b.lobster test_a.lobster lobster.conf
 	@lobster-report
 	@if diff report.lobster $(REFERENCE_OUTPUT); then \
 	    echo "Files are identical"; \

--- a/tests_integration/projects/coverage_mix/trlc_req_a.conf
+++ b/tests_integration/projects/coverage_mix/trlc_req_a.conf
@@ -1,3 +1,0 @@
-coverage_mix.Requirement_A {
-  description = text
-}

--- a/tests_integration/projects/coverage_mix/trlc_req_b.conf
+++ b/tests_integration/projects/coverage_mix/trlc_req_b.conf
@@ -1,3 +1,0 @@
-coverage_mix.Requirement_B {
-  description = text
-}

--- a/tests_integration/projects/coverage_mix/trlc_test_spec.conf
+++ b/tests_integration/projects/coverage_mix/trlc_test_spec.conf
@@ -1,6 +1,0 @@
-coverage_mix.Test_Specification {
-  description = text
-  tags "req"  = verifies
-  just_up     = just_up
-  just_down   = just_down
-}

--- a/tests_integration/projects/coverage_zero/Makefile
+++ b/tests_integration/projects/coverage_zero/Makefile
@@ -7,7 +7,7 @@ THIS_TEST:=$(shell realpath --relative-to $(LOBSTER_ROOT) $(PWD))
 THIS_TEST_ESCAPED:=$(subst /,\\/,$(THIS_TEST))
 REFERENCE_OUTPUT:=report.reference_output
 
-html_report.html: softreq.lobster sysreq.lobster lobster.conf trlc-softreq.conf trlc-sysreq.conf
+html_report.html: softreq.lobster sysreq.lobster lobster.conf
 	@lobster-report
 	@if diff report.lobster $(REFERENCE_OUTPUT); then \
 	    echo "Files are identical"; \

--- a/tests_integration/projects/coverage_zero/trlc-softreq.conf
+++ b/tests_integration/projects/coverage_zero/trlc-softreq.conf
@@ -1,4 +1,0 @@
-coverage_zero.Software_Requirement {
-  description = text
-  tags "req"  = derived_from
-}

--- a/tests_integration/projects/coverage_zero/trlc-sysreq.conf
+++ b/tests_integration/projects/coverage_zero/trlc-sysreq.conf
@@ -1,3 +1,0 @@
-coverage_zero.System_Requirement {
-  description = text
-}


### PR DESCRIPTION
The tests still depended on files that contain the old variant of the `lobster-trlc` configuration.

Furthermore the `make integration-tests` target always deleted the `MODULE.bazel` and `MODULE.bazel.lock` files, which contain real content since the beginning of the introduction of Bazel to the repository.