### PR TITLE
Use TRLC v2.0.2 with Bazel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### 0.14.4-dev
 
-
+* Increased the TRLC version to 2.0.2 when running `lobster-trlc` with Bazel.
 
 ### 0.14.3
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -50,7 +50,7 @@ bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
 use_repo(python, "python_3_9")
 
 git_override(
-    commit = "5deb2da28265d7a6a7e6e0a8ca69d3f372530c70",
+    commit = "650b51a47264a4f232b3341f473527710fc32669",
     module_name = "trlc",
     remote = "https://github.com/bmw-software-engineering/trlc.git",
 )


### PR DESCRIPTION
Update the commit hash, which references the TRLC repository, to use the release commit of v2.0.2

This affects the execution of `lobster-trlc` with Bazel. A regular installation through `pip` is not affected by this change.