### PR TITLE
Restrict `package.yml` to `main` branch

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,7 @@ jobs:
   package:
     name: Build
     runs-on: ubuntu-24.04
+    if: github.event.release.target_commitish == 'main'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9
@@ -37,6 +38,7 @@ jobs:
     name: PyPI Upload
     needs: package
     runs-on: ubuntu-24.04
+    if: github.event.release.target_commitish == 'main'
     environment: release
     permissions:
       id-token: write


### PR DESCRIPTION
The publication of wheel files to pypi.org shall be triggered only for releases that were built on the main branch.
This commit introduces a corresponding condition so that jobs will run only on the `main` branch.