### PR TITLE
Read command line arguments from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,43 @@
 
 ### 0.14.1-dev
 
+* Add feature to read command line arguments from a file for the following tools:
 
+  - `lobster-trlc`
+  - `lobster-codebeamer`
+  - `lobster-cpp`
+  - `lobster-gtest`
+  - `lobster-pkg`
+  - `lobster-python`
+  - `lobster-ci-report`
+  - `lobster-online-report`
+  - `lobster-online-report-nogit`
+  - `lobster-html-report`
+  - `lobster-report`
+
+  This feature allows to specify a path to a file which contains command line arguments.
+  The path must be prefixed with the `@` character so that the above mentioned tools
+  understand that the argument is a path to an argument file (and not an argument on its
+  own).
+
+  Example:
+
+
+  ```sh
+  > lobster-report --version
+  ```
+
+  could be replaced by
+
+  ```sh
+  > lobster-cpptest @arguments.txt
+  ```
+
+  where the content of `arguments.txt` is as follows:
+
+  ```txt
+  --version
+  ```
 
 ### 0.14.0
 

--- a/lobster/meta_data_tool_base.py
+++ b/lobster/meta_data_tool_base.py
@@ -34,6 +34,7 @@ class MetaDataToolBase(metaclass=ABCMeta):
                       if official else None),
             allow_abbrev = False,
             formatter_class=RawTextHelpFormatter,
+            fromfile_prefix_chars="@",  # lobster-trace: req.Args_From_File
         )
         self._argument_parser.add_argument(
             "-v",

--- a/lobster/tools/trlc/requirements/requirements.trlc
+++ b/lobster/tools/trlc/requirements/requirements.trlc
@@ -7,3 +7,10 @@ req.System_Requirement Output_File {
       Otherwise, the output shall be written to 'trlc.lobster'.
     '''
 }
+
+req.Software_Requirement Args_From_File {
+    description = '''
+      If a command line argument is prefixed with '@', then the contents of that file
+      shall be included as arguments to the argument parser.
+    '''
+}


### PR DESCRIPTION
Add feature to read command line arguments from a file for the following tools:

  - `lobster-trlc`
  - `lobster-codebeamer`
  - `lobster-cpp`
  - `lobster-gtest`
  - `lobster-pkg`
  - `lobster-python`
  - `lobster-ci-report`
  - `lobster-online-report`
  - `lobster-online-report-nogit`
  - `lobster-html-report`
  - `lobster-report`

  This feature allows to specify a path to a file which contains command line arguments.
  The path must be prefixed with the `@` character so that the above mentioned tools
  understand that the argument is a path to an argument file (and not an argument on its
  own).

  Example:


  ```sh
  > lobster-report --version
  ```

  could be replaced by

  ```sh
  > lobster-cpptest @arguments.txt
  ```

  where the content of `arguments.txt` is as follows:

  ```txt
  --version