### PR TITLE
Test cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ lint-system-tests: style
 		tests_system/lobster_meta_data_tool_base \
 		tests_system/lobster_online_report \
 		tests_system/lobster_online_report_nogit \
-		tests_system/lobster_report
+		tests_system/lobster_report \
+		tests_system/lobster_trlc \
+		tests_system/lobster_cpp \
+		tests_system/lobster_gtest
 
 lint-unit-tests: style
 	@PYTHONPATH=$(SYSTEM_PYTHONPATH) \

--- a/tests_system/lobster_meta_data_tool_base/lobster_meta_data_tool_base_asserters.py
+++ b/tests_system/lobster_meta_data_tool_base/lobster_meta_data_tool_base_asserters.py
@@ -6,13 +6,21 @@ from ..asserter import Asserter
 IMPLEMENTATION_MESSAGE = "This is the AppleBanana tool."
 
 
-class SpecialAsserter(Asserter, metaclass=ABCMeta):
+class SpecificAsserter(Asserter, metaclass=ABCMeta):
+    """This class is an abstract base class. Implementors shall provide an
+       implementation for the `assert_result` method.
+    """
+
     @abstractmethod
     def assert_result(self):
-        pass
+        """Asserts the result of the tool execution.
+
+           This function shall assert all relevant aspects of the tool's output,
+           including stdout, stderr, and the exit code.
+        """
 
 
-class HelpAsserter(SpecialAsserter):
+class HelpAsserter(SpecificAsserter):
     def assert_result(self):
         """Assert that
           - the help message is printed correctly
@@ -43,7 +51,7 @@ class HelpAsserter(SpecialAsserter):
         self.assertExitCode(0)
 
 
-class VersionAsserter(SpecialAsserter):
+class VersionAsserter(SpecificAsserter):
     def assert_result(self):
         """Assert that
           - the version message is printed correctly

--- a/tests_system/lobster_meta_data_tool_base/test_meta_data_tool_base.py
+++ b/tests_system/lobster_meta_data_tool_base/test_meta_data_tool_base.py
@@ -4,7 +4,7 @@ from .lobster_meta_data_tool_base_system_test_case_base import (
     LobsterMetaDataToolBaseSystemTestCaseBase,
 )
 from .lobster_meta_data_tool_base_asserters import (
-    SpecialAsserter, HelpAsserter, VersionAsserter, IMPLEMENTATION_MESSAGE
+    SpecificAsserter, HelpAsserter, VersionAsserter, IMPLEMENTATION_MESSAGE
 )
 from ..asserter import Asserter
 
@@ -17,7 +17,7 @@ class ToolBaseTest(LobsterMetaDataToolBaseSystemTestCaseBase):
     @dataclass
     class ArgumentSetup:
         argument_variants: Tuple[str, str]
-        asserter_cls: Type[SpecialAsserter]
+        asserter_cls: Type[SpecificAsserter]
 
     def test_early_exit_arguments(self):
         """Test that 'help' and 'version' cmd arguments trigger early exit

--- a/tests_system/lobster_trlc/test_conversion_errors.py
+++ b/tests_system/lobster_trlc/test_conversion_errors.py
@@ -1,7 +1,6 @@
-from typing import Optional
-from dataclasses import dataclass
-from .lobster_system_test_case_base import LobsterTrlcSystemTestCaseBase
-from ..asserter import Asserter
+from tests_system.asserter import Asserter
+from tests_system.lobster_trlc.lobster_system_test_case_base import \
+    LobsterTrlcSystemTestCaseBase
 
 
 class ConversionRuleErrorTest(LobsterTrlcSystemTestCaseBase):

--- a/tests_system/pylint3.cfg
+++ b/tests_system/pylint3.cfg
@@ -4,6 +4,7 @@ disable=
  invalid-name,
  missing-docstring,
  duplicate-code,
+ fixme,
 
 [REPORTS]
 output-format=text


### PR DESCRIPTION
- Rename class `SpecialAsserter` to `SpecificAsserter`, and  add comments.
- Delete obsolete import statements.
- Include more system tests in `lint-system-tests`