### PR TITLE
Simplify Test Data

### DIFF
--- a/tests_system/lobster_json/data/input_dir_mix/test_one.json
+++ b/tests_system/lobster_json/data/input_dir_mix/test_one.json
@@ -1,19 +1,13 @@
 [
     {
-	"name"   : "Test_1",
-	"tags"   : null,
-	"inputs" : [1, 0],
-	"expect" : 1
+        "name": "Test_1",
+        "tags": null
     },
     {
-	"name"   : "Test_2",
-	"tags"   : "example.req4",
-	"inputs" : [1, 0],
-	"expect" : 1
+        "name": "Test_2",
+        "tags": "example.req4"
     },
     {
-	"name"   : "Test_3",
-	"inputs" : [1, 0],
-	"expect" : 1
+        "name": "Test_3"
     }
 ]

--- a/tests_system/lobster_json/data/valid_directory/test_one.json
+++ b/tests_system/lobster_json/data/valid_directory/test_one.json
@@ -1,21 +1,15 @@
 [
     {
-	"name"   : "Test_1",
-	"tags"   : ["example.req1"],
-	"inputs" : [1, 2],
-	"expect" : 3
+        "name": "Test_1",
+        "tags": ["example.req1"]
     },
     {
-	"name"   : "Test_2",
-	"tags"   : [],
-	"inputs" : [1, 0],
-	"expect" : 1
+        "name": "Test_2",
+        "tags": []
     },
     {
-	"name"   : "Test_3",
-	"tags"   : ["example.req2",
-		    "example.req3"],
-	"inputs" : [1, 0],
-	"expect" : 1
+        "name": "Test_3",
+        "tags": ["example.req2",
+                 "example.req3"]
     }
 ]


### PR DESCRIPTION
Reduce the content of the test data for system tests of `lobster-json` to the minimum that is necessary for the tests.

This way the test files can also help new users to understand how the tool works.

Also replaced tab with whitespace in those files, to beautify the indentation.