### PR TITLE
Remove Dependency to SetupTools

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,7 +103,6 @@ py_library(
         "//lobster/tools/python",
         "//lobster/tools/trlc",
         requirement("requests"),
-        requirement("setuptools"),
         requirement("trlc"),
     ],
 )


### PR DESCRIPTION
`setuptools` is only needed to build `*.wheel` files, so there is no need to make it available through Bazel.