### PR TITLE
Prevent empty HTML output file in case of rendering failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### 0.14.4-dev
 
+* `lobster-html-report`:
+  - Improved error handling: if the tool has an internal error it no longer creates an
+    empty output file (except in very rare scenarios where the OS succeeds to open the
+    file but fails to write content to it, e.g. if disk space is exhausted).
 * Increased the TRLC version to 2.0.2 when running `lobster-trlc` with Bazel.
 * `lobster-online-report`:
   - Improved support for git submodules.

--- a/lobster/tools/core/html_report/html_report.py
+++ b/lobster/tools/core/html_report/html_report.py
@@ -283,7 +283,7 @@ def generate_custom_data(report) -> str:
     return "".join(content)
 
 
-def write_html(fd, report, dot, high_contrast, render_md):
+def write_html(report, dot, high_contrast, render_md) -> str:
     assert isinstance(report, Report)
 
     doc = htmldoc.Document(
@@ -579,7 +579,7 @@ def write_html(fd, report, dot, high_contrast, render_md):
             with open(filename, "r", encoding="UTF-8") as scripts:
                 doc.scripts.append("".join(scripts.readlines()))
 
-    fd.write(doc.render() + "\n")
+    return doc.render()
 
 
 class HtmlReportTool(MetaDataToolBase):
@@ -614,15 +614,16 @@ class HtmlReportTool(MetaDataToolBase):
         report = Report()
         report.load_report(options.lobster_report)
 
+        html_content = write_html(
+            report = report,
+            dot = options.dot,
+            high_contrast = options.high_contrast,
+            render_md = options.render_md,
+        )
         with open(options.out, "w", encoding="UTF-8") as fd:
-            write_html(
-                fd = fd,
-                report = report,
-                dot = options.dot,
-                high_contrast = options.high_contrast,
-                render_md = options.render_md,
-            )
-            print("LOBSTER HTML report written to %s" % options.out)
+            fd.write(html_content)
+            fd.write("\n")
+        print(f"LOBSTER HTML report written to {options.out}")
 
         return 0
 


### PR DESCRIPTION
Modify the `html_report.py` such that it tries to open the output file for writing only once the HTML string has been fully constructed.

Imagine the following piece of code:

```python
with open("file.txt", "w", encoding="UTF-8") as f:
    raise NotImplementedError("Error!")
```

Here an empty file (size 0) will be created.

The previous implementation of `html_report.py` behaved similarly. If the rendering of the HTML report failed (e.g. due to a bug) the tool nevertheless created an empty file.

This is inconvenient behavior for the user, since the tool tricks the user into thinking it succeeded. And the user will be disappointed when looking at the output file.

The updated implementation simply creates the HTML string first, and tries to open the output file for writing only afterwards.