### PR TITLE
Add Bazel targets for missing tests

### DIFF
--- a/tests_system/lobster_json/BUILD.bazel
+++ b/tests_system/lobster_json/BUILD.bazel
@@ -83,3 +83,21 @@ py_test(
         "//tests_system",
     ],
 )
+
+py_test(
+    name = "test_config_exceptions",
+    srcs = ["test_config_exceptions.py"],
+    deps = [
+        ":lobster_json",
+        "//tests_system",
+    ],
+)
+
+py_test(
+    name = "test_valid_input",
+    srcs = ["test_valid_input.py"],
+    deps = [
+        ":lobster_json",
+        "//tests_system",
+    ],
+)

--- a/tests_system/lobster_json/test_config_exceptions.py
+++ b/tests_system/lobster_json/test_config_exceptions.py
@@ -1,6 +1,8 @@
 from yaml.scanner import ScannerError
-from .lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
-from .lobsterjsonasserter import LobsterJsonAsserter
+from tests_system.lobster_json.lobsterjsonasserter import LobsterJsonAsserter
+from tests_system.lobster_json.lobsterjsonsystemtestcasebase import (
+    LobsterJsonSystemTestCaseBase
+)
 
 
 class ConfigParserExceptionsLobsterJsonTest(LobsterJsonSystemTestCaseBase):

--- a/tests_system/lobster_json/test_valid_input.py
+++ b/tests_system/lobster_json/test_valid_input.py
@@ -1,5 +1,7 @@
-from .lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
-from ..asserter import Asserter
+from tests_system.asserter import Asserter
+from tests_system.lobster_json.lobsterjsonsystemtestcasebase import (
+    LobsterJsonSystemTestCaseBase
+)
 
 
 class ValidInputTest(LobsterJsonSystemTestCaseBase):

--- a/tests_system/lobster_report/BUILD.bazel
+++ b/tests_system/lobster_report/BUILD.bazel
@@ -83,3 +83,12 @@ py_test(
         "//tests_system",
     ],
 )
+
+py_test(
+    name = "test_justification",
+    srcs = ["test_justification.py"],
+    deps = [
+        ":lobster_report",
+        "//tests_system",
+    ],
+)


### PR DESCRIPTION
Tests from `lobster-json` and lobster-report` were not included in the bazel targets. Also, modified import statemts to use relative import in those test files.
