### PR TITLE
`lobster-online-report` supports only HTTPS

### DIFF
--- a/documentation/manual-lobster_online_report_nogit.md
+++ b/documentation/manual-lobster_online_report_nogit.md
@@ -8,7 +8,7 @@ There are two tools, `lobster-online-report` and `lobster-online-report-nogit`.
 Both tools replace file references in a `*.lobster` file with GitHub references,
 with the following difference:
 - `lobster-online-report` calls `git` and extracts the necessary information like
-  remote URL by itself,
+  submodule URL by itself,
 - `lobster-online-report-nogit` does not call `git`, but the user provides the
   necessary information through command line arguments.
 

--- a/packages/lobster-core/README.md
+++ b/packages/lobster-core/README.md
@@ -15,9 +15,23 @@ The report is in JSON, but you can generate more readable versions of it
 with additional tools:
 
 * `lobster-online-report`:
-  Preprocess a JSON report to contain github references instead of local file
+  Postprocess a `*.lobster` report to contain GitHub references instead of local file
   references.
-  Repository information is retrieved by calling the `git` tool.
+  Repository information must partly be provided as configuration parameters, and is partly retrieved by calling the `git` tool.
+  Note that the tool only works in combination with submodules if the `.gitmodules` file of the repository uses HTTPS urls instead of SSH.
+
+  If your `.gitmodules` looks like this, you can use this tool:
+
+  ```ini
+  [submodule "farm-with-palms"]
+    path = coconut/farm
+    url = ../farm-with-palms
+    branch = .
+  ```
+
+  But if your file contains URLs ending on `.git`, you cannot use this tool.
+  It will build invalid URLs.
+
 * `lobster-online-report-nogit`:
   This tool is similar to `lobster-online-report`, but it does not
   call the `git` tool to obtain information about the repository.


### PR DESCRIPTION
The tool `lobster-online-report` supports only HTTPS URLS in `.gitmodules`. The documentation has been updated accordingly.