### PR TITLE
Update cpptest usecases, requirements & potential errors for tool qualification.

### DIFF
--- a/lobster/tools/codebeamer/requirements/potential_errors.trlc
+++ b/lobster/tools/codebeamer/requirements/potential_errors.trlc
@@ -22,7 +22,6 @@ import req
       ]
 
       affects = [
-         Trace_Requirements_to_Tests,
          List_Requirements_to_Tests,
          List_Requirements_without_Tests,
          List_Tests_to_Requirements,
@@ -45,7 +44,6 @@ import req
       ]
 
       affects = [
-         Trace_Requirements_to_Tests,
          List_Requirements_to_Tests,
          List_Requirements_without_Tests,
          List_Tests_to_Requirements,
@@ -68,7 +66,6 @@ import req
       ]
 
       affects = [
-         Trace_Requirements_to_Tests,
          List_Requirements_to_Tests,
          List_Requirements_without_Tests,
          List_Tests_to_Requirements,

--- a/lobster/tools/core/html_report/requirements/potential_errors.trlc
+++ b/lobster/tools/core/html_report/requirements/potential_errors.trlc
@@ -17,7 +17,7 @@ req.PotentialError Requirements_not_listed_correctly{
           then user might think that all requirements are not covered by the tests but in fact it is not the case.'''
     ]
 
-    affects = [Trace_Requirements_to_Tests, List_Requirements_to_Tests, List_Requirements_without_Tests]
+    affects = [List_Requirements_to_Tests, List_Requirements_without_Tests]
     impact_type = req.Impact_Type.Safety
 }
 
@@ -37,7 +37,7 @@ req.PotentialError Software_tests_not_listed_correctly{
           then user might think that all requirements are not covered by software tests but in fact that is not the case.'''
     ]
 
-    affects = [Trace_Requirements_to_Tests, List_Tests_to_Requirements, List_Tests_without_Requirements]
+    affects = [List_Tests_to_Requirements, List_Tests_without_Requirements]
     impact_type = req.Impact_Type.Safety
 }
 
@@ -54,7 +54,7 @@ req.PotentialError Incorrect_mapping_in_HTML_File{
           then user might think that requirement is covered but in fact it is not.'''
     ]
 
-    affects = [Trace_Requirements_to_Tests, List_Tests_to_Requirements, List_Tests_without_Requirements, List_Requirements_to_Tests, List_Requirements_without_Tests]
+    affects = [List_Tests_to_Requirements, List_Tests_without_Requirements, List_Requirements_to_Tests, List_Requirements_without_Tests]
     impact_type = req.Impact_Type.Safety
 }
 

--- a/lobster/tools/cpptest/requirements/potential_errors.trlc
+++ b/lobster/tools/cpptest/requirements/potential_errors.trlc
@@ -17,7 +17,12 @@ req.PotentialError Too_few_Extraction_from_CPP_Test_Files{
           then there might be tests which are not based on requirements, which could mean the product contains hidden features.'''
     ]
 
-    affects = [List_Tests_without_Requirements, List_Tests_without_Requirements, Trace_Requirements_to_Tests]
+    affects = [
+      List_Tests_without_Requirements,
+      List_Requirements_to_Tests,
+      List_Requirements_without_Tests,
+      List_Tests_to_Requirements
+    ]
     impact_type = req.Impact_Type.Safety
 }
 
@@ -37,7 +42,12 @@ req.PotentialError Too_few_requirement_referance_Extraction_from_test{
           then user might think that test cases are missing reference but in fact it is not.'''   
     ]
 
-    affects = [List_Tests_without_Requirements, List_Tests_without_Requirements, Trace_Requirements_to_Tests]
+    affects = [
+      List_Tests_without_Requirements,
+      List_Requirements_to_Tests,
+      List_Requirements_without_Tests,
+      List_Tests_to_Requirements
+    ]
     impact_type = req.Impact_Type.Safety
 }
 
@@ -57,7 +67,12 @@ req.PotentialError Too_many_Extraction_from_CPP_Test_Files{
           then user might think that all requirements are not covered by c++ tests but in fact they are covered.'''
     ]
 
-    affects = [List_Tests_without_Requirements, List_Tests_without_Requirements, Trace_Requirements_to_Tests]
+    affects = [
+      List_Tests_without_Requirements,
+      List_Requirements_to_Tests,
+      List_Requirements_without_Tests,
+      List_Tests_to_Requirements
+    ]
     impact_type = req.Impact_Type.Safety
 }
 
@@ -74,7 +89,12 @@ req.PotentialError Too_many_requirement_referance_Extraction_from_test{
           then user might think that all requirements are covered by the software tests but in fact it is not the case.'''
     ]
 
-    affects = [List_Tests_without_Requirements, List_Tests_without_Requirements, Trace_Requirements_to_Tests]
+    affects = [
+      List_Tests_without_Requirements, 
+      List_Requirements_to_Tests,
+      List_Requirements_without_Tests,
+      List_Tests_to_Requirements
+    ]
     impact_type = req.Impact_Type.Safety
 }
 
@@ -95,7 +115,6 @@ req.PotentialError Output_Despite_Missing_Config_File {
     ]
 
     affects = [
-      Trace_Requirements_to_Tests,
       List_Requirements_to_Tests,
       List_Requirements_without_Tests,
       List_Tests_to_Requirements,
@@ -123,7 +142,6 @@ req.PotentialError Output_Despite_Config_File_Error {
     ]
 
     affects = [
-      Trace_Requirements_to_Tests,
       List_Requirements_to_Tests,
       List_Requirements_without_Tests,
       List_Tests_to_Requirements,

--- a/lobster/tools/trlc/requirements/potential_errors.trlc
+++ b/lobster/tools/trlc/requirements/potential_errors.trlc
@@ -22,7 +22,6 @@ req.PotentialError Default_Path_Choice {
         '''
     ]
     affects = [
-        Trace_Requirements_to_Tests,
         List_Requirements_to_Tests,
         List_Requirements_without_Tests,
         List_Tests_to_Requirements,

--- a/lobster/use_cases.trlc
+++ b/lobster/use_cases.trlc
@@ -1,26 +1,6 @@
 package UseCases
 import req
 
-req.UseCase Trace_Requirements_to_Tests {
-    description = '''
-        As a requirements manager I want to have a report of traceability between
-        requirements and tests.
-    '''
-    affected_tools = [
-        // shall extract requirements:
-        req.Tools.lobster_codebeamer,
-        req.Tools.lobster_trlc,
-
-        // shall extract test cases:
-        req.Tools.lobster_json,
-        req.Tools.lobster_cpptest,
-
-        // shall generate reports:
-        req.Tools.lobster_report,
-        req.Tools.lobster_html_report
-    ]
-}
-
 req.UseCase List_Requirements_to_Tests {
     description = '''
         As a requirements manager I want the traceability report to show the list of


### PR DESCRIPTION
Update usecases.trlc for cpptest, delete duplicate use case - Trace_Requirements_to_Tests, Modify trlc files to remove the deleted usecase