### PR TITLE
`lobster-pkg`: use cases, potential errors and system tests

### DIFF
--- a/lobster/tools/pkg/requirements/extraction_rules.trlc
+++ b/lobster/tools/pkg/requirements/extraction_rules.trlc
@@ -1,0 +1,67 @@
+package req
+
+
+System_Requirement Pkg_Invalid_Xml {
+    description = 
+    '''
+        IF at least one input file is invalid XML,
+        THEN the tool shall exit with non-zero return code.
+    '''
+}
+
+System_Requirement Pkg_File_Item {
+    description =
+    '''
+        The tool SHALL create a LOBSTER output item of type "Activity" for each input file
+        IF the file represents a test case, identified by having an <INFORMATION> node
+        with a <TITLE> child node containing the string "TESTCASE"
+        OR IF a lobster-trace is given in an ANALYSIS block
+        (details see [[Trace_in_Analysis_Node]]).
+
+        The following requirements describe how to fill the "refs" attribute of these
+        items.
+
+        Note: If no requirements is fulfilled, which describes how to fill the "refs" attribute,
+        then the item SHALL be created with an empty "refs" attribute.
+    '''
+}
+
+System_Requirement Trace_in_Test_Step_Node {
+    description = '''
+        Note: Pay attention to the difference between TESTSTEP and TESTSTEPS!
+
+        The tool SHALL extract all tags (marked by "lobster-trace") from <VALUE> nodes
+        from the specified input files
+        WHERE all of the following conditions apply:
+        - The file SHALL be a test case, identified by having an <INFORMATION> node
+        with a <TITLE> child node containing the string "TESTCASE".
+        - The <TESTSTEPS> node is of type "testCase".
+        - The <TESTSTEP> node is the first child node of a <TESTSTEPS> node.
+        - The <TESTSTEP> node is named "TsBlock".
+        - The <VALUE> node is nested inside a <TESTSTEP> node.
+        - The <VALUE> node contains one or more substrings in the format
+        "lobster-trace:<REQUIREMENT_ID>"
+    '''
+}
+
+System_Requirement Trace_in_Analysis_Node {
+    description = '''
+        The tool SHALL extract all tags (marked by "lobster-trace") from <DESCRIPTION> nodes
+        from the specified input files
+        WHERE all of the following conditions apply:
+        - The <ANALYSISITEM> node is a **direct** child node of a <TRACE-ANALYSIS> node.
+        - The <ANALYSISITEM> node is of type "episode".
+        - The <DESCRIPTION> node is a **direct** child node of an <ANALYSISITEM> node.
+        - The <DESCRIPTION> node contains the substring in the format
+        "lobster-trace:<REQUIREMENT_ID>"
+    '''
+}
+
+System_Requirement Misplaced_Traces {
+    description =
+    '''
+        The tool SHALL print a warning for tags in <DESCRIPTION> and <VALUE> nodes
+        which do not match the conditions of the requirements
+        [[Trace_in_Test_Step_Node]] and [[Trace_in_Analysis_Node]].
+    '''
+}

--- a/lobster/tools/pkg/requirements/potential_errors.trlc
+++ b/lobster/tools/pkg/requirements/potential_errors.trlc
@@ -1,0 +1,201 @@
+package UseCases
+import req
+
+req.PotentialError Invalid_XML_Ignored {
+    summary = "lobster-pkg ignores invalid XML files"
+    description = '''
+        If at least one input file is invalid XML, the tool might ignore this fact
+        and continue processing the other files.
+        '''
+    impacts = [
+        '''If the tool ignores invalid XML files, then the quality manager might think
+           that all specified input files were valid and processed correctly.
+           This can lead the quality manager to a false conclusion, because she/he might
+           believe that all tests in the specified files were considered,
+           while in reality some files were ignored.
+        ''',
+    ]
+    affects = [
+        List_Requirements_to_Tests,
+        List_Requirements_without_Tests,
+        List_Tests_to_Requirements,
+        Item_Coverage,
+    ]
+    impact_type = req.Impact_Type.Safety
+}
+
+req.PotentialError Default_Path_Choice_pkg {
+    summary = '''A default directory is used as source of input files without notifying
+                 the user'''
+    description = '''
+        If no input files are specified, the tool might inadvertently use the current
+        working directory (or any other default value for these configuration parameters)
+        as the location to search for input files.
+        '''
+    impacts = [
+        '''
+        The assumption here is that the user wanted to specify input paths, but forgot
+        to do so, or that the user did not realize that the tool would use the current
+        working directory.
+        This can lead to unintended consequences, because it is hard for the user to
+        detect their mistake, since a report will be generated if the wrong folder
+        contains valid input files.
+        This is especially problematic if the tool is executed in an automated
+        environment, like a CI/CD pipeline.
+        '''
+    ]
+    affects = [
+        List_Requirements_to_Tests,
+        List_Requirements_without_Tests,
+        List_Tests_to_Requirements,
+        Item_Coverage,
+    ]
+    impact_type = req.Impact_Type.Safety
+}
+
+req.PotentialError Wrong_Extraction_from_PKG {
+    summary = "lobster-pkg extracts data wrongly"
+    description = '''
+        The data of the items in the output file is not consistent with the data in the input files.
+        '''
+    impacts = [
+        '''If the data of the XML node is parsed incorrectly 
+           (e.g. items wrongly mapped - data of items A and B interchanged)
+           then the quality manager might think that 
+           an item is linked to another item
+           (e.g. test from PKG file is linked against a requirement)
+           where in reality it is not.
+        ''',
+    ]
+    affects = [
+        List_Requirements_to_Tests,
+        List_Requirements_without_Tests,
+        List_Tests_to_Requirements,
+        Item_Coverage,
+    ]
+    impact_type = req.Impact_Type.Safety
+}
+
+req.PotentialError Too_many_PKG_files {
+    summary = "lobster-pkg extracts too many items"
+    description = '''
+        Some non-relevant *.pkg files or *.ta files are consumed.
+        For example, some items are extracted from files which are not specified as input
+        by the user (but which could be found in the same folder as the specified input
+        files).
+        '''
+    impacts = [
+        '''If the tool creates fake items whose IDs are actually referenced by other
+           items, then the final report may incorrectly show a higher coverage value than
+           the true value.
+           The quality manager expects the report to highlight that items point to
+           non-existent items, but instead the error leads to an incorrect coverage
+           result.
+        ''',
+    ]
+    affects = [
+        List_Requirements_to_Tests,
+        List_Requirements_without_Tests,
+        List_Tests_to_Requirements,
+        Item_Coverage,
+    ]
+    impact_type = req.Impact_Type.Safety
+}
+
+req.PotentialError Too_many_Output_Items {
+    summary = "lobster-pkg creates fake output items"
+    description = '''
+        The tool creates fake output items, which do not correspond to any real input
+        items.
+        '''
+    impacts = [
+        '''If the tool creates fake items which are referenced by other items,
+           or which reference real other items on their own,
+           then the final report may incorrectly show a higher coverage value than the
+           true value.
+           The quality manager expects the report to highlight that items point to
+           non-existent items, but instead the error leads to an incorrect coverage
+           result.
+        ''',
+    ]
+    affects = [
+        List_Requirements_to_Tests,
+        List_Requirements_without_Tests,
+        List_Tests_to_Requirements,
+        Item_Coverage,
+    ]
+    impact_type = req.Impact_Type.Safety
+}
+
+req.PotentialError Too_few_Extraction_from_PKG {
+    summary = "lobster-pkg extracts too few items"
+    description = '''
+        Some items are not extracted from input files.
+        For example, there are 100 applicable items in the input files but
+        the tool extracts only 42 items.
+        '''
+    impacts = [
+        '''The tool generally extracts only tests where a lobster-trace is found.
+           It does not extract orphan tests.
+
+           This is different to tools like lobster-cpptest, which extracts all tests,
+           including orphan tests that do not have a trace (usually pointing to a
+           requirement).
+
+           The quality manager can use the generated output of lobster-pkg only to
+           determine the items which are covered by tests in PKG/TA files, but not vice
+           versa.
+           The quality manager cannot use the output to determine if all tests fulfill
+           the tracing policy.
+
+           If lobster-pkg does not issue a warning for misplaced traces,
+           then the situation is the same as if the test in the input file had no trace
+           at all.
+
+           Hence the impact type is "Financial", not "Safety".
+           There is only the risk that the test engineer needs to spend more time to
+           manually check if all tests in the input files are covered by requirements.
+        ''',
+    ]
+    affects = [
+        List_Requirements_to_Tests,
+        List_Tests_to_Requirements,
+        Item_Coverage,
+    ]
+    impact_type = req.Impact_Type.Financial
+}
+
+req.PotentialError No_Warning_for_Misplaced_Trace {
+    summary = "lobster-pkg does not warn about misplaced trace elements"
+    description = '''
+        No warning is issued for lobster-traces which do not fulfill the conditions
+        of the requirements [[Trace_in_Test_Step_Node]] and [[Trace_in_Analysis_Node]].
+        '''
+    impacts = [
+        '''The tool generally extracts only tests where a lobster-trace is found.
+           It does not extract orphan tests.
+
+           This is different to tools like lobster-cpptest, which extracts all tests,
+           including orphan tests that do not have a trace (usually pointing to a
+           requirement).
+
+           The quality manager can use the generated output of lobster-pkg only to
+           determine the items which are covered by tests in PKG/TA files, but not vice
+           versa.
+           The quality manager cannot use the output to determine if all tests fulfill
+           the tracing policy.
+
+           If lobster-pkg does not issue a warning for misplaced traces,
+           then the situation is the same as if the test in the input file had no trace
+           at all.
+
+           Hence the impact type is "Financial", not "Safety".
+           There is only the risk that the test engineer needs to spend more time to
+           manually check if all tests in the input files are covered by requirements.
+        ''',
+    ]
+    affects = [
+        PKG_Misplaced_Trace_Warning,
+    ]
+    impact_type = req.Impact_Type.Financial
+}

--- a/lobster/tools/pkg/requirements/test_specifications.trlc
+++ b/lobster/tools/pkg/requirements/test_specifications.trlc
@@ -1,0 +1,42 @@
+package UseCases
+import req
+
+
+req.TestSpecification PKG_Files_Missing {
+    description = '''
+        The test shall verify that the lobster-pkg tool exits with a non-zero return code when the pkg files do not exist.
+        Example: Verify that the lobster-pkg tool throws an error when a non-existent pkg file is provided.
+    '''
+    verifies = [Default_Path_Choice_pkg]
+}
+
+req.TestSpecification PKG_Files_Invalid {
+    description = '''
+        The test shall verify that the lobster-pkg tool exits with a non-zero return code when the pkg/ta files are invalid XML.
+        Example: Verify that the lobster-pkg tool throws an error when an invalid pkg/ta file is provided.
+    '''
+    verifies = [Invalid_XML_Ignored]
+}
+
+req.TestSpecification PKG_Items_Extraction {
+    description = '''
+        The test shall verify that the lobster-pkg tool extracts the correct items from the pkg/ta files.
+        Example: Verify that the lobster-pkg tool extracts all relevant items from the provided pkg/ta files.
+    '''
+    verifies = [Wrong_Extraction_from_PKG, Too_few_Extraction_from_PKG, Too_many_Output_Items, Too_many_PKG_files]
+}
+
+req.TestSpecification Warning_for_Misplaced_Trace {
+    description = '''
+        The test shall verify that the lobster-pkg tool does warn user about misplaced traces in pkg/ta files.
+        Example: Verify that the lobster-pkg tool processes pkg/ta files with misplaced traces and
+        that a warning is issued in the console output.
+
+        Test steps:
+        - Provide a PKG or TA XML file with <VALUE> or <DESCRIPTION> nodes containing "lobster-trace:REQUIREMENT_ID"
+          but placed outside the valid locations described in [[Trace_in_Test_Step_Node]] and [[Trace_in_Analysis_Node]].
+        - Run the tool and verify that a warning is printed for each misplaced tag, including location information.
+    '''
+    verifies = [No_Warning_for_Misplaced_Trace]
+}
+

--- a/lobster/tools/trlc/requirements/potential_errors.trlc
+++ b/lobster/tools/trlc/requirements/potential_errors.trlc
@@ -93,11 +93,14 @@ req.PotentialError Too_many_Extraction_from_TRLC {
            requirements are not tested where in reality those extracted items are
            not into considerations or irrelavent requirements.''',
 
-        '''If lobster-trlc creates fake requirements and another tool like lobster-cpptest
-           extracts tests from C++ that reference these fake requirement IDs,
-           the HTML report may incorrectly show 100% coverage.
-           The user expects the report to highlight that C++ tests point to non-existent
-           requirements, but instead, the error leads to a misleading coverage result.'''
+        '''If the tool creates fake items which are referenced by other items,
+           or which reference real other items on their own,
+           then the final report may incorrectly show a higher coverage value than the
+           true value.
+           The quality manager expects the report to highlight that items point to
+           non-existent items, but instead the error leads to an incorrect coverage
+           result.
+        ''',
     ]
     affects = [
         List_Requirements_to_Tests,
@@ -113,15 +116,15 @@ req.PotentialError Output_Despite_Missing_Config_File_TRLC {
     summary = "Output generated without configuration file"
     description = '''
       The user does not provide a valid path to a configuration file,
-      but the lobster-trlc generates valid output nevertheless, potentially based on
-      irrelevant rsl and trlc files.
-      For example, the lobster-trlc might consider the current working directory
-      as source of rsl and trlc files, and these do in fact contain links to real requirements,
+      but the tool generates valid output nevertheless, potentially based on
+      irrelevant input files.
+      For example, the tool might consider the current working directory
+      as source of input files, and these do in fact contain links to real other items,
       such that lobster-report would compute a non-zero coverage value.
     '''
     impacts = [
-      '''If the lobster-trlc generates a valid output file, then the invalid input path could
-        remain undetected, and subsequent tools of the LOBSTER tool chain
+      '''If the tool generates a valid output file, then the invalid input path could
+        remain undetected, and subsequent tools of the LOBSTER tool suite
         could consume unqualified input data.''',
     ]
 
@@ -138,17 +141,18 @@ req.PotentialError Output_Despite_Missing_Config_File_TRLC {
 req.PotentialError Output_Despite_Config_File_Error_TRLC {
     summary = "Output generated with an invalid configuration file"
     description = '''
-      The user provides an invalid configuration file, but the lobster-trlc
+      The user provides an invalid configuration file, but the tool
       generates valid output nevertheless, potentially based on
-      irrelevant rsl and trlc files.
+      irrelevant input files.
       This includes cases where the config file:
       - contains invalid YAML syntax (e.g., incorrect indentation, missing colons, or other formatting errors),
       - is missing required keys or attributes,
     '''
     impacts = [
-      '''If the lobster-trlc generates a valid output file, then the invalid configuration file could
-        remain undetected, and subsequent tools of the LOBSTER tool chain
-        could consume unqualified input data.''',
+      '''If the tool generates a valid output file, then the invalid configuration file could
+         remain undetected, and subsequent tools of the LOBSTER tool suite
+         could consume unqualified input data.
+      ''',
     ]
 
     affects = [

--- a/lobster/use_cases.trlc
+++ b/lobster/use_cases.trlc
@@ -68,6 +68,8 @@ req.UseCase List_Tests_without_Requirements {
     description = '''
         As a requirements manager I want the traceability report to show the list of
         tests which are not covering any requirement.
+
+        This use case does not apply to tests in PKG/TA files (from ecu.test).
     '''
     affected_tools = [
         // shall extract requirements:
@@ -77,7 +79,10 @@ req.UseCase List_Tests_without_Requirements {
         // shall extract test cases:
         req.Tools.lobster_json,
         req.Tools.lobster_cpptest,
-        req.Tools.lobster_pkg,
+        /* Note: lobster-pkg cannot contribute to this use case, because it only extracts
+         * tests which have a trace to another item.
+         * It does not extract orphan tests without a trace by design.
+         */
 
         // shall generate reports:
         req.Tools.lobster_report,
@@ -215,6 +220,17 @@ section "Nice to have" {
         '''
         affected_tools = [
             req.Tools.lobster_html_report
+        ]
+    }
+
+    req.UseCase PKG_Misplaced_Trace_Warning {
+        description = '''
+            As a requirements manager I want lobster-pkg to print a warning
+            for lobster-traces in <DESCRIPTION> and <VALUE> nodes
+            which are not extracted (due to wrong XML node or path properties).
+        '''
+        affected_tools = [
+            req.Tools.lobster_pkg,
         ]
     }
 }

--- a/tests_system/lobster_pkg/test_invalid_scenario.py
+++ b/tests_system/lobster_pkg/test_invalid_scenario.py
@@ -10,6 +10,8 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
         self._test_runner = self.create_test_runner()
 
     def test_not_existing_pkg_file(self):
+        """Test that a missing input file causes non-zero exit code"""
+        # lobster-trace: UseCases.PKG_Files_Missing
         OUT_FILE = "not_existing.lobster"
         non_existing_file = str(
             self._data_directory / "not_existing.pkg")
@@ -22,7 +24,20 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertInStdErr(f'{non_existing_file} is not a file or directory')
         asserter.assertExitCode(1)
 
+    def test_missing_input_parameter(self):
+        """Test that not specifying an input file causes non-zero exit code"""
+        # lobster-trace: UseCases.PKG_Files_Missing
+        self._test_runner.cmd_args.files = []
+        self._test_runner.cmd_args.out = "will-not-be-generated.lobster"
+
+        completed_process = self._test_runner.run_tool_test()
+        asserter = LobsterPkgAsserter(self, completed_process, self._test_runner)
+        asserter.assertInStdErr('the following arguments are required: FILE|DIR')
+        asserter.assertExitCode(2)
+
     def test_not_existing_output_path(self):
+        """Test that a missing output path causes non-zero exit code"""
+        # lobster-trace: UseCases.PKG_Files_Missing
         OUT_FILE = "not_existing/not_existing.lobster"
         self._test_runner.cmd_args.files = [
             str(self._data_directory / "valid_file1.pkg")
@@ -36,6 +51,9 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(1)
 
     def test_misplaced_lobster_trace_file(self):
+        """Test that a misplaced lobster-trace in ANALYSISITEM causes a warning
+           but exit code 0"""
+        # lobster-trace: UseCases.Warning_for_Misplaced_Trace
         OUT_FILE = "report.lobster"
         misplaced_lobster_trace_file = str(
             self._data_directory / "misplaced_lobster_trace.pkg")
@@ -53,6 +71,8 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(0)
 
     def test_misplaced_tags_file(self):
+        """Test that a misplaced lobster-trace in TESTSTEPS causes non-zero exit code"""
+        # lobster-trace: UseCases.Warning_for_Misplaced_Trace
         OUT_FILE = "report.lobster"
         misplaced_tags_file_name = "misplaced_tags.pkg"
         misplaced_tags_file_path = str(
@@ -69,6 +89,8 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(1)
 
     def test_invalid_xml_file(self):
+        # lobster-trace: UseCases.PKG_Files_Invalid
+        # lobster-trace: req.Pkg_Invalid_Xml
         OUT_FILE = "report.lobster"
         invalid_xml_file_name = "invalid_xml.pkg"
         invalid_xml_file_path = str(

--- a/tests_system/lobster_pkg/test_valid_scenario.py
+++ b/tests_system/lobster_pkg/test_valid_scenario.py
@@ -12,6 +12,10 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         self._test_runner = self.create_test_runner()
 
     def test_valid_input_pkg_file(self):
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Trace_in_Test_Step_Node
+        # lobster-trace: req.Trace_in_Analysis_Node
         OUT_FILE = "valid_file1.lobster"
         self._test_runner.declare_input_file(self._data_directory / "valid_file1.pkg")
         self._test_runner.cmd_args.files = ["valid_file1.pkg"]
@@ -29,6 +33,9 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertOutputFiles()
 
     def test_valid_input_ta_file(self):
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Trace_in_Analysis_Node
         OUT_FILE = "valid_ta_file.lobster"
         self._test_runner.declare_input_file(self._data_directory / "valid_file.ta")
         self._test_runner.cmd_args.files = ["valid_file.ta"]
@@ -46,6 +53,10 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertOutputFiles()
 
     def test_valid_ta_file_with_misplaced_traces(self):
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: UseCases.Warning_for_Misplaced_Trace
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Misplaced_Traces
         OUT_FILE = "with_misplaced_traces.lobster"
         self._test_runner.cmd_args.files = [
             str(self._data_directory / "with_misplaced_traces.ta")
@@ -69,6 +80,10 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(0)
 
     def test_valid_pkg_file_with_misplaced_traces(self):
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: UseCases.Warning_for_Misplaced_Trace
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Misplaced_Traces
         OUT_FILE = "valid_file1.lobster"
         self._test_runner.cmd_args.files = [
             str(self._data_directory / "with_misplaced_traces.pkg")
@@ -92,6 +107,10 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(0)
 
     def test_valid_input_pkg_files(self):
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Trace_in_Test_Step_Node
+        # lobster-trace: req.Trace_in_Analysis_Node
         OUT_FILE = "valid_file1_and_valid_file2.lobster"
         for file in ("valid_file1.pkg", "valid_file2.pkg"):
             self._test_runner.declare_input_file(self._data_directory / file)
@@ -110,7 +129,35 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
 
+    def test_valid_input_file_and_extra_file(self):
+        """Test that an extra file in the working directory is ignored."""
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Trace_in_Test_Step_Node
+        # lobster-trace: req.Trace_in_Analysis_Node
+        OUT_FILE = "valid_file1.lobster"
+        IN_FILES = ("valid_file1.pkg", "valid_file2.pkg")
+        for f in IN_FILES:
+            self._test_runner.copy_file_to_working_directory(self._data_directory / f)
+        self._test_runner.cmd_args.files.append(IN_FILES[0])
+
+        out_file = self._data_directory / OUT_FILE
+        self._test_runner.declare_output_file(out_file)
+
+        self._test_runner.cmd_args.out = OUT_FILE
+        completed_process = self._test_runner.run_tool_test()
+
+        asserter = LobsterPkgAsserter(self, completed_process, self._test_runner)
+        asserter.assertNoStdErrText()
+        asserter.assertStdOutNumAndFile(1, OUT_FILE)
+        asserter.assertExitCode(0)
+        asserter.assertOutputFiles()
+
     def test_valid_input_pkg_folder(self):
+        # lobster-trace: UseCases.PKG_Items_Extraction
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: req.Trace_in_Test_Step_Node
+        # lobster-trace: req.Trace_in_Analysis_Node
         OUT_FILE = "valid_file1_folder.lobster"
 
         pkg_files_dir = Path(self._test_runner.working_dir) / "pkg_files"
@@ -135,6 +182,8 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertOutputFiles()
 
     def test_valid_file_without_lobster_trace(self):
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: UseCases.PKG_Items_Extraction
         OUT_FILE = "without_lobster_trace.lobster"
         self._test_runner.declare_input_file(self._data_directory /
                                              "without_lobster_trace.pkg")
@@ -153,6 +202,8 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertOutputFiles()
 
     def test_valid_file_without_testcase_tag(self):
+        # lobster-trace: req.Pkg_File_Item
+        # lobster-trace: UseCases.PKG_Items_Extraction
         OUT_FILE = "without_testcase_tag.lobster"
         self._test_runner.declare_input_file(self._data_directory /
                                              "without_testcase_tag.pkg")


### PR DESCRIPTION
I recommend to merge https://github.com/bmw-software-engineering/lobster/pull/474 first, and then rebase the current branch onto `main`.

For `lobster-pkg`:
- add system requirements
- add potential errors
- add system test case to cover all potential errors

Also align the formulation between the potential errors of the tools `lobster-pkg` and `lobster-trlc` such that they both use the term "tool" instead of the actual tool name. This way we can potentially unify the potential errors in the future in order to reduce maintenance effort.