### PR TITLE
TRLC : Added traces for test-specifications

### DIFF
--- a/lobster/tools/trlc/requirements/test_specifications.trlc
+++ b/lobster/tools/trlc/requirements/test_specifications.trlc
@@ -49,3 +49,11 @@ req.TestSpecification TRLC_Config_File_Key_Error {
     '''
     verifies = [Output_Despite_Config_File_Error_TRLC]
 }
+
+req.TestSpecification TRLC_Config_File_non_existent_conversion_rules {
+    description = '''
+        The test shall verify that lobster-trlc tool exits with a non-zero return code when the config file contains
+        conversion rules for TRLC record types which do not exist in the RSL file.
+    '''
+    verifies = [Output_Despite_Config_File_Error_TRLC]
+}

--- a/tests_system/lobster_trlc/lobster_system_test_case_base.py
+++ b/tests_system/lobster_trlc/lobster_system_test_case_base.py
@@ -22,6 +22,14 @@ class LobsterTrlcSystemTestCaseBase(SystemTestCaseBase):
         super().__init__(methodName)
         self._data_directory = Path(__file__).parents[0] / "data"
 
+    def create_test_runner_without_config_file_data(self) -> LobsterTrlcTestRunner:
+        tool_name = Path(__file__).parents[0].name
+        test_runner = LobsterTrlcTestRunner(
+            self.create_temp_dir(prefix=f"test-{tool_name}-"),
+            use_config_file_data=False
+        )
+        return test_runner
+
     def create_test_runner(self) -> LobsterTrlcTestRunner:
         tool_name = Path(__file__).parents[0].name
         test_runner = LobsterTrlcTestRunner(

--- a/tests_system/lobster_trlc/lobster_trlc_test_runner.py
+++ b/tests_system/lobster_trlc/lobster_trlc_test_runner.py
@@ -38,7 +38,7 @@ class ConfigFileData:
 
 @dataclass
 class CmdArgs:
-    config: Optional[str] = "config.yaml"
+    config: Optional[str] = None
     out: Optional[str] = None
     dir_or_files: Optional[List[str]] = None
 
@@ -59,10 +59,14 @@ class CmdArgs:
 
 class LobsterTrlcTestRunner(TestRunner):
     """System test runner for lobster-TRLC"""
-    def __init__(self, working_dir: Path):
+    def __init__(self, working_dir: Path, use_config_file_data: bool = True):
         super().__init__(main, working_dir)
-        self._config_file_data = ConfigFileData()
-        self._cmd_args = CmdArgs()
+        self.use_config_file_data = use_config_file_data
+        if use_config_file_data:
+            self._cmd_args = CmdArgs(config="config.yaml")
+            self._config_file_data = ConfigFileData()
+        else:
+            self._cmd_args = CmdArgs()
 
     @property
     def cmd_args(self) -> CmdArgs:
@@ -96,6 +100,6 @@ class LobsterTrlcTestRunner(TestRunner):
         return self._cmd_args.as_list()
 
     def run_tool_test(self) -> TestRunResult:
-        if self._cmd_args.config:
+        if self._cmd_args.config and self.use_config_file_data:
             self._config_file_data.dump(str(self._working_dir / self._cmd_args.config))
         return super().run_tool_test()

--- a/tests_system/lobster_trlc/test_conversion.py
+++ b/tests_system/lobster_trlc/test_conversion.py
@@ -50,6 +50,7 @@ class ConversionRuleTest(LobsterTrlcSystemTestCaseBase):
 
         for setup in test_setups:
             with self.subTest(setup=setup.name):
+                # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
                 out_file = f"extraction_hierarchy_{setup.name}.out.lobster"
                 test_runner = self.create_test_runner()
                 test_runner.cmd_args.out = out_file
@@ -80,6 +81,7 @@ class ConversionRuleTest(LobsterTrlcSystemTestCaseBase):
 
     def test_to_string_rules(self):
         """Test that to_string rules are applied correctly."""
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
         test_runner = self.create_test_runner()
         out_file = "to_string_rules.out.lobster"
         test_runner.cmd_args.out = out_file

--- a/tests_system/lobster_trlc/test_conversion_errors.py
+++ b/tests_system/lobster_trlc/test_conversion_errors.py
@@ -6,6 +6,7 @@ from tests_system.lobster_trlc.lobster_system_test_case_base import \
 class ConversionRuleErrorTest(LobsterTrlcSystemTestCaseBase):
     def test_field_does_not_exist(self):
         """Test that an error is raised when field does not exist in the record type."""
+        # lobster-trace: UseCases.TRLC_Config_File_Key_Error
         test_runner = self.create_test_runner()
         test_runner.cmd_args.out = "will-not-be-generated.lobster"
         rules = {
@@ -33,6 +34,7 @@ class ConversionRuleErrorTest(LobsterTrlcSystemTestCaseBase):
 
     def test_to_string_missing(self):
         """Test that a missing to-string rule causes an error"""
+        # lobster-trace: UseCases.TRLC_Config_File_Key_Error
         test_runner = self.create_test_runner()
         test_runner.cmd_args.out = "will-not-be-generated.lobster"
         test_runner.config_file_data.conversion_rules = [
@@ -67,6 +69,7 @@ class ConversionRuleErrorTest(LobsterTrlcSystemTestCaseBase):
 
     def test_tuple_member_does_not_exist(self):
         """Test that a to_string rule causes error if a tuple member does not exist."""
+        # lobster-trace: UseCases.TRLC_Config_File_Key_Error
         test_runner = self.create_test_runner()
         test_runner.cmd_args.out = "will-not-be-generated.lobster"
         test_runner.config_file_data.conversion_rules = [
@@ -104,6 +107,7 @@ class ConversionRuleErrorTest(LobsterTrlcSystemTestCaseBase):
 
     def test_too_many_conversion_rules(self):
         """Test that orphan conversion rules are detected."""
+        # lobster-trace: UseCases.TRLC_Config_File_non_existent_conversion_rules
         test_runner = self.create_test_runner()
         test_runner.cmd_args.out = "will-not-be-generated.lobster"
         test_runner.config_file_data.conversion_rules = [

--- a/tests_system/lobster_trlc/test_input_invalid_extensions.py
+++ b/tests_system/lobster_trlc/test_input_invalid_extensions.py
@@ -13,6 +13,7 @@ class TrlcInvalidExtensionsTest(LobsterTrlcSystemTestCaseBase):
 
     def test_invalid_extensions_inputs_files_list(self):
         # lobster-trace: trlc_req.Invalid_Inputs_List_Of_Files_Extensions
+        # lobster-trace: UseCases.TRLC_Config_File_Syntax_Error
         self._test_runner.declare_input_file(self._data_directory /
                                              "rsl_invalid_extension.slr")
         self._test_runner.declare_input_file(self._data_directory /
@@ -27,6 +28,7 @@ class TrlcInvalidExtensionsTest(LobsterTrlcSystemTestCaseBase):
 
     def test_invalid_extensions_input_from_file(self):
         # lobster-trace: trlc_req.Invalid_Inputs_From_File_Extensions
+        # lobster-trace: UseCases.TRLC_Config_File_Syntax_Error
         self._test_runner.declare_inputs_from_file(self._data_directory /
                                                    "invalid_ext_inputs_from_file.txt",
                                                    self._data_directory)

--- a/tests_system/lobster_trlc/test_input_list_of_files.py
+++ b/tests_system/lobster_trlc/test_input_list_of_files.py
@@ -12,6 +12,7 @@ class InputListOfFilesTest(LobsterTrlcSystemTestCaseBase):
 
     def test_input_files_list(self):
         # lobster-trace: trlc_req.Input_List_Of_Files
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
         self._test_runner.config_file_data.conversion_rules = [
             self.NAMASTE_CONVERSION_RULE,
         ]
@@ -52,6 +53,7 @@ class InputListOfFilesTest(LobsterTrlcSystemTestCaseBase):
 
 class CmdArgsInputTest(LobsterTrlcSystemTestCaseBase):
     def test_input_files_list(self):
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
         """Test that input files can be specified as command line arguments"""
         test_runner = self.create_test_runner()
 

--- a/tests_system/lobster_trlc/test_inputs_and_inputs_from_file.py
+++ b/tests_system/lobster_trlc/test_inputs_and_inputs_from_file.py
@@ -17,6 +17,7 @@ class InputFromFilesAndInputsTest(LobsterTrlcSystemTestCaseBase):
     def test_input_from_files_and_inputs_list(self):
         """Test that inputs from files and inputs list can be processed together."""
         # lobster-trace: trlc_req.Input_list_Of_File_And_Inputs_From_File
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
         OUT_FILE = "input_from_files_and_inputs.lobster"
         self._test_runner.cmd_args.out = OUT_FILE
         self._test_runner.declare_output_file(self._data_directory / OUT_FILE)

--- a/tests_system/lobster_trlc/test_inputs_from_directory.py
+++ b/tests_system/lobster_trlc/test_inputs_from_directory.py
@@ -16,6 +16,8 @@ class InputFromDirectory(LobsterTrlcSystemTestCaseBase):
 
     def test_input_from_directory(self):
         """Test that a directory is processed"""
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
+
         # TODO: the test folder structure is not recursive, but it should be
         OUT_FILE = "input_from_working_directory.lobster"
         self._test_runner.cmd_args.out = OUT_FILE

--- a/tests_system/lobster_trlc/test_inputs_from_file.py
+++ b/tests_system/lobster_trlc/test_inputs_from_file.py
@@ -13,6 +13,7 @@ class InputFromFilesTest(LobsterTrlcSystemTestCaseBase):
 
     def test_input_from_files(self):
         # lobster-trace: trlc_req.Inputs_From_File
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
         OUT_FILE = "input_from_files.lobster"
         self._test_runner.cmd_args.out = OUT_FILE
         self._test_runner.declare_output_file(self._data_directory / OUT_FILE)

--- a/tests_system/lobster_trlc/test_inputs_zero.py
+++ b/tests_system/lobster_trlc/test_inputs_zero.py
@@ -13,6 +13,7 @@ class ZeroInputTest(LobsterTrlcSystemTestCaseBase):
 
     def test_rsl_input_only(self):
         """Test that output is empty if no *.trlc inputs are provided, only *.rsl."""
+        # lobster-trace: UseCases.Default_Path_Warning_Test
         self._test_runner.config_file_data.conversion_rules = [
             self.BERRY_CONVERSION_RULE,
         ]
@@ -38,6 +39,7 @@ class ZeroInputTest(LobsterTrlcSystemTestCaseBase):
                  are found (because the input is empty).
         """
         # lobster-trace: trlc_req.No_Inputs_At_All
+        # lobster-trace: UseCases.Default_Path_Warning_Test
         self._test_runner.config_file_data.conversion_rules = []
         OUT_FILE = "zero_items.lobster"
         self._test_runner.cmd_args.out = OUT_FILE
@@ -49,9 +51,12 @@ class ZeroInputTest(LobsterTrlcSystemTestCaseBase):
         asserter.assertExitCode(0)
 
     def test_orphan_conversion_rules(self):
-        """Test that output is not generated if no inputs are provided."""
+        """
+        Test that when conversion rules are not provided
+        then the tool shall raise an error
+        """
         # lobster-trace: trlc_req.No_Inputs_At_All
-
+        # lobster-trace: UseCases.TRLC_Config_File_Key_Error
         self._test_runner.config_file_data.conversion_rules = [
             self.BERRY_CONVERSION_RULE,
             self.NAMASTE_CONVERSION_RULE,

--- a/tests_system/lobster_trlc/test_invalid_config.py
+++ b/tests_system/lobster_trlc/test_invalid_config.py
@@ -12,6 +12,8 @@ class InvalidConfigTest(LobsterTrlcSystemTestCaseBase):
 
     def test_nonconformant_yaml(self):
         """Test that non-conformant YAML file results in error."""
+        # lobster-trace: UseCases.TRLC_Config_File_Syntax_Error
+        # lobster-trace: UseCases.TRLC_Config_File_Key_Error
         self._test_runner.cmd_args.out = "will-not-be-generated.lobster"
         self.assertFalse(
             self._test_runner.config_file_data.conversion_rules,
@@ -23,4 +25,53 @@ class InvalidConfigTest(LobsterTrlcSystemTestCaseBase):
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertInStdErr("conversion-rules: Required field missing")
         asserter.assertNoStdOutText()
+        asserter.assertExitCode(1)
+
+
+class MissingConfigTest(LobsterTrlcSystemTestCaseBase):
+
+    def setUp(self):
+        super().setUp()
+        self._test_runner = self.create_test_runner_without_config_file_data()
+
+    def test_missing_config_parameter(self):
+        # lobster-trace: UseCases.TRLC_Config_File_Missing
+        out_file = "missing_config_file.lobster"
+        self._test_runner.cmd_args.out = out_file
+        self._test_runner.declare_output_file(self._data_directory / out_file)
+
+        completed_process = self._test_runner.run_tool_test()
+        asserter = Asserter(self, completed_process, self._test_runner)
+
+        # assertInStdErr is being used instead of assertStdErrText because the output is
+        # truncated when Python version is 3.9 and above.
+        # But for Python version 3.8 the full output is shown.
+
+        # Incase of Python >-3.9 the error message is:
+        # 'usage: lobster-trlc [-h] [-v] [--out OUT] --config CONFIG [DIR|FILE ...]\n'
+        # 'lobster-trlc: error: the following arguments are required: --config\n'
+
+        # For Python 3.8 the full error message is:
+        # 'usage: lobster-trlc [-h] [-v] [--out OUT] --config CONFIG
+        # [DIR|FILE [DIR|FILE ...]]\n'
+        # 'lobster-trlc: error: the following arguments are required: --config\n'
+        asserter.assertInStdErr("usage: lobster-trlc [-h] [-v] [--out OUT] "
+                                "--config CONFIG")
+        asserter.assertInStdErr("lobster-trlc: error: the following arguments "
+                                "are required: --config")
+        asserter.assertExitCode(2)
+
+    def test_missing_config_file(self):
+        # lobster-trace: UseCases.TRLC_Config_File_Missing
+        out_file = "missing_config_file.lobster"
+        self._test_runner.cmd_args.out = out_file
+        self._test_runner.cmd_args.config = str(
+            self._test_runner.working_dir / "non_existant.yaml")
+        self._test_runner.declare_output_file(self._data_directory / out_file)
+
+        completed_process = self._test_runner.run_tool_test()
+        asserter = Asserter(self, completed_process, self._test_runner)
+        asserter.assertInStdErr("lobster-trlc: File or directory not found: "
+                                "[Errno 2] No such file or directory:",
+                                completed_process.stderr)
         asserter.assertExitCode(1)

--- a/tests_system/lobster_trlc/test_output_correctness.py
+++ b/tests_system/lobster_trlc/test_output_correctness.py
@@ -17,6 +17,7 @@ class OutputCorrectnessTest(LobsterTrlcSystemTestCaseBase):
            set, so we can verify that each output item is populated with data only
            based on one single input item.
         """
+        # lobster-trace: UseCases.Incorrect_data_Extraction_from_TRLC
         self._test_runner.cmd_args.out = "output_correctness_test.out.lobster"
         self._test_runner.declare_output_file(
             self._data_directory / self._test_runner.cmd_args.out)


### PR DESCRIPTION
Contains the following changes for `lobster-trlc`.

1. Adds traces of test specifications to the system tests.
2. New system test for missing config file.
3. Point 2 required some changes to be made to the test infra of `lobster-trlc`.