### PR TITLE
Update potential error and test specification for lobster-html-report

### DIFF
--- a/lobster/tools/core/html_report/requirements/potential_errors.trlc
+++ b/lobster/tools/core/html_report/requirements/potential_errors.trlc
@@ -108,10 +108,10 @@ req.PotentialError Too_few_findings_in_HTML_report{
     impact_type = req.Impact_Type.Safety
 }
 
-req.PotentialError Wrong_Input_file_location{
-    summary = "LOBSTER shows the wrong location of the input files"
+req.PotentialError Wrong_Input_location{
+    summary = "LOBSTER shows the wrong location of the input source"
     description = '''
-      Source location of the input file is incorrect in HTML report.
+      Source location of the input source is incorrect in HTML report.
     '''
     impacts = [
       '''If URL of the git repo is not correct in HTML report

--- a/lobster/tools/core/html_report/requirements/test_specifications.trlc
+++ b/lobster/tools/core/html_report/requirements/test_specifications.trlc
@@ -38,11 +38,11 @@ req.TestSpecification HTML_file_generation{
 
 req.TestSpecification Source_location_in_output{
     description = '''
-      The test shall verify that correct source locations of the input files are mentioned in the HTML report.
+      The test shall verify that correct source locations of the inputs (url) are mentioned in the HTML report.
       
       example: Verify HTML file contains correct source location URL from which c++ test file is taken
     '''
-    verifies = [Input_file_location_missing, Wrong_Input_file_location]
+    verifies = [Input_file_location_missing, Wrong_Input_location]
 }
 
 req.TestSpecification Missing_tracing_policy_violation_in_output{


### PR DESCRIPTION
- Rename `Wrong_Input_file_location` to `Wrong_Input_location`
- Update summary and description to use "input source" instead of "input files"
- Update test specification `Source_location_in_output` to reference the renamed potential error
- Clarify description to mention "inputs (url)"