### PR TITLE
Fix tool name in help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 * `lobster-html-report`:
   Unused `id` attribute from `h5` tag in the HTML report was removed.
+* `lobster-online-report`:
+  Fixed tool name in help message.
+* `lobster-report`:
+  Fixed tool name in help message.
+* `lobster-ci-report`:
+  Fixed tool name in help message.
 
 ### 0.14.5
 

--- a/lobster/tools/core/ci_report/ci_report.py
+++ b/lobster/tools/core/ci_report/ci_report.py
@@ -29,7 +29,7 @@ from lobster.common.meta_data_tool_base import MetaDataToolBase
 class CiReportTool(MetaDataToolBase):
     def __init__(self):
         super().__init__(
-            name="lobster-ci-report",
+            name="ci-report",
             description="Command line tool to check a LOBSTER report",
             official=True,
         )

--- a/lobster/tools/core/online_report/online_report.py
+++ b/lobster/tools/core/online_report/online_report.py
@@ -48,9 +48,6 @@ class Config:
     report: str = "report.lobster"
 
 
-TOOL_NAME = "lobster-online-report"
-
-
 def load_config(file_name: str) -> Config:
     if not os.path.isfile(file_name):
         raise FileNotFoundError(f'{file_name} is not an existing file!')
@@ -162,7 +159,7 @@ def add_github_reference_to_items(
 class OnlineReportTool(MetaDataToolBase):
     def __init__(self):
         super().__init__(
-            name="lobster-online-report",
+            name="online-report",
             description="Update file locations in LOBSTER report to GitHub references.",
             official=True,
         )
@@ -194,9 +191,8 @@ class OnlineReportTool(MetaDataToolBase):
             self._print_error(lobster_error)
         return 1
 
-    @staticmethod
-    def _print_error(error: Union[Exception, str]):
-        print(f"{TOOL_NAME}: {error}", file=sys.stderr)
+    def _print_error(self, error: Union[Exception, str]):
+        print(f"{self.name}: {error}", file=sys.stderr)
 
     @staticmethod
     def _execute(options: Namespace) -> None:

--- a/lobster/tools/core/report/report.py
+++ b/lobster/tools/core/report/report.py
@@ -29,7 +29,7 @@ from lobster.common.meta_data_tool_base import MetaDataToolBase
 class ReportTool(MetaDataToolBase):
     def __init__(self):
         super().__init__(
-            name="lobster-report",
+            name="report",
             description="Generate a LOBSTER report from a lobster.conf file",
             official=True,
         )

--- a/tests_system/lobster_report/test_json_scanario.py
+++ b/tests_system/lobster_report/test_json_scanario.py
@@ -22,7 +22,7 @@ class ReportInvalidJsonTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdErrText()
         asserter.assertStdOutText("trlc_invalid_json.lobster:6:2: "
                                   "lobster error: Extra data\n\n"
-                                  "lobster-lobster-report: aborting due "
+                                  "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)
 
@@ -73,6 +73,6 @@ class ReportInvalidJsonTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdErrText()
         asserter.assertStdOutText("trlc_json_not_dict.lobster: "
                                   "lobster error: parsed json is not an object\n\n"
-                                  "lobster-lobster-report: aborting due "
+                                  "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)

--- a/tests_system/lobster_report/test_multiple_inputs.py
+++ b/tests_system/lobster_report/test_multiple_inputs.py
@@ -73,7 +73,7 @@ class ReportMultipleInputTest(LobsterReportSystemTestCaseBase):
             "multiple_traces_just.conf:11: lobster error: cannot find file "
             "multiple_traces_test.lobster\n"
             "\n"
-            "lobster-lobster-report: aborting due to earlier errors.\n"
+            "lobster-report: aborting due to earlier errors.\n"
         )
         asserter.assertExitCode(1)
 

--- a/tests_system/lobster_report/test_schema_and_version.py
+++ b/tests_system/lobster_report/test_schema_and_version.py
@@ -25,7 +25,7 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
         asserter.assertStdOutText("python_invalid_schema.lobster: "
                                   "lobster error: unknown schema kind "
                                   "invalid-schema-name\n\n"
-                                  "lobster-lobster-report: aborting due "
+                                  "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)
 
@@ -43,7 +43,7 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
         asserter.assertStdOutText("trlc_missing_schema.lobster: "
                                   "lobster error: required top-levelkey "
                                   "schema not present\n\n"
-                                  "lobster-lobster-report: aborting due "
+                                  "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)
 
@@ -64,7 +64,7 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
         asserter.assertStdOutText("python_invalid_version.lobster: "
                                   "lobster error: version 99 for schema "
                                   "lobster-req-trace is not supported\n\n"
-                                  "lobster-lobster-report: aborting due "
+                                  "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)
 
@@ -82,6 +82,6 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
         asserter.assertStdOutText("trlc_missing_version.lobster: "
                                   "lobster error: required top-levelkey "
                                   "version not present\n\n"
-                                  "lobster-lobster-report: aborting due "
+                                  "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)


### PR DESCRIPTION
The tool `lobster-online-report` printed the name
"lobster-lobster-online-report" instead of "lobster-online-report" when running the tool with `--help`.
The message has been fixed.
The above issue was also affecting `lobster-ci-report` & `lobster-report`. It is fixed now.