### PR TITLE
fix: GitHub URLs in lobster traceability reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,8 +278,9 @@ tracing-stf: $(STF_TRLC_FILES)
 	python lobster-trlc.py --config=lobster/tools/lobster-trlc-software-stf.yaml --out=stf_software_requirements.lobster
 	python lobster-python.py --out=stf_code.lobster --only-tagged-functions $(STF_PYTHON_FILES)
 	python lobster-report.py --lobster-config=tests_system/stf-lobster.conf --out=stf_report.lobster
-	python lobster-online-report.py stf_report.lobster
-	python lobster-html-report.py stf_report.lobster --out=$(STF_OUTPUT_FILE)
+	@printf "report: stf_report.lobster\ncommit_id: 'main'\nrepo_root: ''\nbase_url: 'https://github.com/bmw-software-engineering/lobster'" > online_report_config.yaml
+	python lobster-online-report.py --config=online_report_config.yaml --out=stf-online-report.lobster
+	python lobster-html-report.py stf-online-report.lobster --out=$(STF_OUTPUT_FILE)
 	@echo "✅ STF report generated at $(STF_OUTPUT_FILE)"
 	@echo "Deleting STF *.lobster files..."
-	rm -f stf_system_requirements.lobster stf_software_requirements.lobster stf_code.lobster stf_report.lobster
+	rm -f stf_system_requirements.lobster stf_software_requirements.lobster stf_code.lobster stf_report.lobster online_report_config.yaml

--- a/tracing/tracing.sh
+++ b/tracing/tracing.sh
@@ -54,7 +54,10 @@ for tool in "${TOOLS[@]}"; do
             --out=tracing_out/tracing.lobster
 
         # Generate online report
-        printf "report: tracing_out/tracing.lobster\ncommit_id: ''\nrepo_root: ''\nbase_url: 'https://github.com/bmw-software-engineering/lobster'" > tracing_out/online_report_config.yaml
+        printf "report: tracing_out/tracing.lobster\n" >> tracing_out/online_report_config.yaml
+        printf "commit_id: 'main'\n" >> tracing_out/online_report_config.yaml
+        printf "repo_root: ''\n" >> tracing_out/online_report_config.yaml
+        printf "base_url: 'https://github.com/bmw-software-engineering/lobster'" >> tracing_out/online_report_config.yaml
         python lobster-online-report.py --config=tracing_out/online_report_config.yaml --out=tracing_out/online-report.lobster
 
         # Generate HTML reports


### PR DESCRIPTION
- Update commit_id 'main' in online report configurations
- Fix missing online report configuration in STF tracing target
- Break long printf commands into multiple lines for better readability

This ensures all generated traceability reports reference the correct github URLs for consistent navigation and linking.