### PR TITLE
Naming convention for all tool APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ### 0.14.6-dev
 
+* Standardized tool API naming convention:
+  - `cb_query_to_lobster_file` → `lobster_codebeamer`
+  - `generate_report_file` → `lobster_report`
+  - `cpptest_items_to_lobster_file` → `lobster_cpptest`
+
 * `lobster-html-report`:
   Unused `id` attribute from `h5` tag in the HTML report was removed.
 

--- a/lobster/tools/codebeamer/codebeamer.py
+++ b/lobster/tools/codebeamer/codebeamer.py
@@ -609,7 +609,7 @@ def _cb_items_to_lobster(items: List[Dict], config: Config, out_file: TextIO) ->
     lobster_write(out_file, schema_config["class"], TOOL_NAME.replace("-", "_"), items)
 
 
-def cb_query_to_lobster_file(config: Config, out_file: str) -> None:
+def lobster_codebeamer(config: Config, out_file: str) -> None:
     """Loads items from codebeamer and serializes them in the LOBSTER interchange
        format to the given file.
     """

--- a/lobster/tools/core/report/report.py
+++ b/lobster/tools/core/report/report.py
@@ -63,7 +63,7 @@ class ReportTool(MetaDataToolBase):
         return 1
 
 
-def generate_report_file(lobster_config_file: str, output_file: str) -> dict:
+def lobster_report(lobster_config_file: str, output_file: str) -> dict:
     # This is an API function to run the lobster report tool
     report = Report()
     report.parse_config(lobster_config_file)

--- a/lobster/tools/cpptest/cpptest.py
+++ b/lobster/tools/cpptest/cpptest.py
@@ -315,7 +315,7 @@ def write_lobster_items_output_dict(lobster_items_output_dict: dict):
                   f'"{output_file_name}".')
 
 
-def lobster_cpptest(config: Config):
+def run_lobster_cpptest(config: Config):
     """
     The main function to parse requirements from comments
     for the given list of files and/or directories and write the
@@ -385,17 +385,17 @@ class CppTestTool(MetaDataToolBase):
     def _execute(options: Namespace) -> None:
         config = parse_config_file(options.config)
 
-        lobster_cpptest(
+        run_lobster_cpptest(
             config=config
         )
 
 
-def cpptest_items_to_lobster_file(config: Config) -> None:
+def lobster_cpptest(config: Config) -> None:
     """Loads items from cpptests and serializes them in the LOBSTER interchange
-       format to the given file.
+        format to the given file.
     """
     # This is an API function.
-    lobster_cpptest(config=config)
+    run_lobster_cpptest(config=config)
 
 
 def main(args: Optional[Sequence[str]] = None) -> int:

--- a/tests_unit/lobster_cpptest/test_cpptest.py
+++ b/tests_unit/lobster_cpptest/test_cpptest.py
@@ -12,7 +12,7 @@ from lobster.tools.cpptest.cpptest import (
     Config,
     collect_test_cases_from_test_files,
     get_test_file_list,
-    lobster_cpptest,
+    run_lobster_cpptest,
     parse_config_file,
 )
 from lobster.tools.cpptest.constants import Constants
@@ -134,7 +134,7 @@ class LobsterCpptestTests(unittest.TestCase):
             output_file=self.output_file_name
         )
 
-        lobster_cpptest(
+        run_lobster_cpptest(
             config=config
         )
 
@@ -165,7 +165,7 @@ class LobsterCpptestTests(unittest.TestCase):
             output_file=self.output_data_file_name
         )
 
-        lobster_cpptest(
+        run_lobster_cpptest(
             config=config
         )
 
@@ -188,7 +188,7 @@ class LobsterCpptestTests(unittest.TestCase):
         )
 
         with self.assertRaises(Exception) as wrapper:
-            lobster_cpptest(
+            run_lobster_cpptest(
                 config=config
             )
 
@@ -202,7 +202,7 @@ class LobsterCpptestTests(unittest.TestCase):
         config: Config = parse_config_file(self.test_config_2)
         config.files = [self.test_case_file]
 
-        lobster_cpptest(
+        run_lobster_cpptest(
             config=config
         )
 

--- a/tests_unit/lobster_report/test_report.py
+++ b/tests_unit/lobster_report/test_report.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 from lobster.common.report import Coverage, Report
-from lobster.tools.core.report.report import generate_report_file
+from lobster.tools.core.report.report import lobster_report
 
 
 class ReportTests(TestCase):
@@ -56,7 +56,7 @@ class ReportTests(TestCase):
         with patch.object(Report, 'parse_config') as mock_parse_config, \
              patch.object(Report, 'write_report') as mock_write_report:
 
-            generate_report_file(
+            lobster_report(
                 lobster_config_file=apple_config,
                 output_file=banana_output
             )


### PR DESCRIPTION
lobster-tools: API naming convention for all tool APIs