### PR TITLE
Add Bazel test target for html report tool test

### DIFF
--- a/tests_system/lobster_html_report/BUILD.bazel
+++ b/tests_system/lobster_html_report/BUILD.bazel
@@ -59,3 +59,14 @@ py_test(
         "//tests_system/tests_utils",
     ],
 )
+
+py_test(
+    name = "test_online_report_input",
+    srcs = ["test_online_report_input.py"],
+    deps = [
+        ":lobster_html_report",
+        "//lobster/tools/core/html_report",
+        "//tests_system",
+        "//tests_system/tests_utils",
+    ],
+)

--- a/tests_system/lobster_html_report/data/BUILD.bazel
+++ b/tests_system/lobster_html_report/data/BUILD.bazel
@@ -1,7 +1,7 @@
 filegroup(
     name = "html_report_data_system",
     srcs = glob([
-        "*.output",
+        "*.html",
         "*.lobster",
     ]),
     visibility = ["//visibility:public"],

--- a/tests_system/tests_utils/BUILD.bazel
+++ b/tests_system/tests_utils/BUILD.bazel
@@ -7,6 +7,12 @@ py_binary(
 )
 
 py_binary(
+    name = "update_html_expected_output",
+    srcs = ["update_html_expected_output.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
     name = "update_online_json_with_hashes",
     srcs = ["update_online_json_with_hashes.py"],
     visibility = ["//visibility:public"],
@@ -23,6 +29,7 @@ py_library(
     srcs = [
         "__init__.py",
         "update_cpptest_expected_output.py",
+        "update_html_expected_output.py",
         "update_online_json_with_hashes.py",
         "update_version_in_html.py",
     ],


### PR DESCRIPTION
Add py_test target for test_online_report_input.py to enable Bazel-based testing of HTML report online input functionality.