### PR TITLE
Fix `lobster-pkg` Use Case

### DIFF
--- a/lobster/tools/pkg/requirements/potential_errors.trlc
+++ b/lobster/tools/pkg/requirements/potential_errors.trlc
@@ -19,6 +19,7 @@ req.PotentialError Invalid_XML_Ignored {
         List_Requirements_to_Tests,
         List_Requirements_without_Tests,
         List_Tests_to_Requirements,
+        List_Tests_without_Requirements,
         Item_Coverage,
     ]
     impact_type = req.Impact_Type.Safety
@@ -48,6 +49,7 @@ req.PotentialError Default_Path_Choice_pkg {
         List_Requirements_to_Tests,
         List_Requirements_without_Tests,
         List_Tests_to_Requirements,
+        List_Tests_without_Requirements,
         Item_Coverage,
     ]
     impact_type = req.Impact_Type.Safety
@@ -71,6 +73,7 @@ req.PotentialError Wrong_Extraction_from_PKG {
         List_Requirements_to_Tests,
         List_Requirements_without_Tests,
         List_Tests_to_Requirements,
+        List_Tests_without_Requirements,
         Item_Coverage,
     ]
     impact_type = req.Impact_Type.Safety
@@ -97,6 +100,7 @@ req.PotentialError Too_many_PKG_files {
         List_Requirements_to_Tests,
         List_Requirements_without_Tests,
         List_Tests_to_Requirements,
+        List_Tests_without_Requirements,
         Item_Coverage,
     ]
     impact_type = req.Impact_Type.Safety
@@ -122,6 +126,7 @@ req.PotentialError Too_many_Output_Items {
         List_Requirements_to_Tests,
         List_Requirements_without_Tests,
         List_Tests_to_Requirements,
+        List_Tests_without_Requirements,
         Item_Coverage,
     ]
     impact_type = req.Impact_Type.Safety
@@ -159,7 +164,9 @@ req.PotentialError Too_few_Extraction_from_PKG {
     ]
     affects = [
         List_Requirements_to_Tests,
+        List_Requirements_without_Tests,
         List_Tests_to_Requirements,
+        List_Tests_without_Requirements,
         Item_Coverage,
     ]
     impact_type = req.Impact_Type.Financial

--- a/lobster/use_cases.trlc
+++ b/lobster/use_cases.trlc
@@ -68,8 +68,6 @@ req.UseCase List_Tests_without_Requirements {
     description = '''
         As a requirements manager I want the traceability report to show the list of
         tests which are not covering any requirement.
-
-        This use case does not apply to tests in PKG/TA files (from ecu.test).
     '''
     affected_tools = [
         // shall extract requirements:
@@ -79,10 +77,7 @@ req.UseCase List_Tests_without_Requirements {
         // shall extract test cases:
         req.Tools.lobster_json,
         req.Tools.lobster_cpptest,
-        /* Note: lobster-pkg cannot contribute to this use case, because it only extracts
-         * tests which have a trace to another item.
-         * It does not extract orphan tests without a trace by design.
-         */
+        req.Tools.lobster_pkg,
 
         // shall generate reports:
         req.Tools.lobster_report,


### PR DESCRIPTION
The use case `List_Tests_without_Requirements` applies very well to the tool `lobster-pkg`. The previously given rationale was wrong.