### PR TITLE
Usecase tracing policy for lobster-online-report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ tracing:
 	@for tool in $(TOOL_FOLDERS); do \
 	echo "Processing tool: $$tool"; \
 		case $$tool in \
-			codebeamer|cpptest|trlc|json|pkg|core-report|core-html_report) \
+			codebeamer|cpptest|trlc|json|pkg|core-report|core-html_report|core-online-report) \
 				echo "Skipping tool: $$tool (handled by tracing.sh script)"; \
 				;; \
 			*) \

--- a/tracing/lobster_online_report/online_report.potential-errors.lobster-trlc.yaml
+++ b/tracing/lobster_online_report/online_report.potential-errors.lobster-trlc.yaml
@@ -1,0 +1,12 @@
+inputs:
+  - "lobster/requirements.rsl"
+  - "lobster/use_cases.trlc"
+  - "lobster/tools/core/online_report"
+conversion-rules:
+  - package: req
+    record-type: PotentialError
+    namespace: req
+    description-fields:
+      - description
+    tags:
+    - affects

--- a/tracing/lobster_online_report/online_report.software-requirements.lobster-trlc.yaml
+++ b/tracing/lobster_online_report/online_report.software-requirements.lobster-trlc.yaml
@@ -1,0 +1,12 @@
+inputs:
+  - "lobster/requirements.rsl"
+  - "lobster/use_cases.trlc"
+  - "lobster/tools/core/online_report"
+conversion-rules:
+  - package: req
+    record-type: Software_Requirement
+    namespace: req
+    description-fields:
+      - description
+    tags:
+    - derived_from

--- a/tracing/lobster_online_report/online_report.system-requirements.lobster-trlc.yaml
+++ b/tracing/lobster_online_report/online_report.system-requirements.lobster-trlc.yaml
@@ -1,0 +1,17 @@
+inputs:
+  - "lobster/requirements.rsl"
+  - "lobster/use_cases.trlc"
+  - "lobster/tools/core/online_report"
+conversion-rules:
+  - package: req
+    record-type: System_Requirement
+    namespace: req
+    description-fields:
+      - description
+  - package: req
+    record-type: System_Requirement_Aspect
+    namespace: req
+    description-fields:
+      - description
+    justification-down-fields:
+      - not_tested_reason

--- a/tracing/lobster_online_report/online_report.test-specifications.lobster-trlc.yaml
+++ b/tracing/lobster_online_report/online_report.test-specifications.lobster-trlc.yaml
@@ -1,0 +1,12 @@
+inputs:
+  - "lobster/requirements.rsl"
+  - "lobster/use_cases.trlc"  
+  - "lobster/tools/core/online_report"
+conversion-rules:
+  - package: req
+    record-type: TestSpecification
+    namespace: req
+    description-fields:
+      - description
+    tags:
+      - verifies

--- a/tracing/tracing.sh
+++ b/tracing/tracing.sh
@@ -4,7 +4,7 @@
 mkdir -p tracing_out
 mkdir -p docs
 
-TOOLS=("codebeamer" "cpptest" "trlc" "json" "pkg" "report" "html_report")
+TOOLS=("codebeamer" "cpptest" "trlc" "json" "pkg" "report" "html_report" "online_report")
 
 # Process each tool
 for tool in "${TOOLS[@]}"; do


### PR DESCRIPTION
- Add online_report to TOOLS list in tracing.sh
- Create TRLC configuration files for online report traceability:
  - online_report.potential-errors.lobster-trlc.yaml
  - online_report.test-specifications.lobster-trlc.yaml
  - online_report.system-requirements.lobster-trlc.yaml
  - online_report.software-requirements.lobster-trlc.yaml
- Skip core-online-report in Makefile tracing target (handled by tracing.sh)
- Enable usecase tracing for online report tool