### PR TITLE
Test specification traces in system tests for html-report

### DIFF
--- a/tests_system/lobster_html_report/test_html_content.py
+++ b/tests_system/lobster_html_report/test_html_content.py
@@ -24,6 +24,7 @@ class LobsterHtmlReportcontentTest(LobsterUISystemTestCaseBase):
         # lobster-trace: UseCases.List_of_tests_Not_covering_requirements_in_HTML_file
         # lobster-trace: UseCases.List_of_tests_covering_requirements_in_HTML_file
         # lobster-trace: UseCases.Source_location_in_output
+        # lobster-trace: UseCases.Missing_tracing_policy_violation_in_output
         """
         This test checks that the data is not mixed
         and unique data in each item processed correctly
@@ -154,6 +155,7 @@ class LobsterHtmlReportcontentTest(LobsterUISystemTestCaseBase):
         # lobster-trace: UseCases.Source_location_in_output
         # lobster-trace: UseCases.HTML_file_generation
         # lobster-trace: UseCases.Not_covered_Requirement_list_in_Output
+        # lobster-trace: UseCases.Missing_tracing_policy_violation_in_output
         """
         This test checks that the tool processes data containing the items
         with multiple status like ok, missing, partial, justified
@@ -240,6 +242,7 @@ class LobsterHtmlReportcontentTest(LobsterUISystemTestCaseBase):
         # lobster-trace: UseCases.List_of_tests_Not_covering_requirements_in_HTML_file
         # lobster-trace: UseCases.List_of_tests_covering_requirements_in_HTML_file
         # lobster-trace: UseCases.Source_location_in_output
+        # lobster-trace: UseCases.Missing_tracing_policy_violation_in_output
         """
         This test checks the input .lobster file has a content in message attributes
         and HTML tool correctly processes it and write correct output file.

--- a/tests_system/lobster_html_report/test_input_file.py
+++ b/tests_system/lobster_html_report/test_input_file.py
@@ -37,6 +37,7 @@ class LobsterHtmlReportInputFileTest(LobsterUISystemTestCaseBase):
 
     def test_valid_lobster_file_succeeds(self):
         # lobster-trace: html_req.Valid_Lobster_File
+        # lobster-trace: UseCases.Missing_tracing_policy_violation_in_output
         """Verify the tool runs successfully with a valid .lobster file."""
         output_filename = "is_actually_html.html"
         valid_inputfile = self._data_directory / "awesome.lobster"
@@ -72,6 +73,7 @@ class LobsterHtmlReportInputFileTest(LobsterUISystemTestCaseBase):
 
     def test_custom_data_displayed_in_report(self):
         # lobster-trace: html_req.HTML_Report_Displays_Custom_data
+        # lobster-trace: UseCases.Missing_tracing_policy_violation_in_output
         """Verify that 'custom_data' values are correctly
         displayed in the HTML report header."""
         dot_present = is_dot_available(dot=None)
@@ -110,6 +112,7 @@ class LobsterHtmlReportInputFileTest(LobsterUISystemTestCaseBase):
 
     def test_valid_md_lobster_file_succeeds(self):
         # lobster-trace: html_req.Valid_Lobster_File_With_Md_Content
+        # lobster-trace: UseCases.Missing_tracing_policy_violation_in_output
         """Verify tool runs successfully with a valid .lobster file with md content."""
         output_filename = "to_render_md_content.html"
         valid_inputfile = self._data_directory / "to_render_md_content.lobster"


### PR DESCRIPTION
Add lobster-trace for UseCases.Missing_tracing_policy_violation_in_output to multiple lobster-html-report system tests

This improves traceability coverage for the lobster-html-report tool