### PR TITLE
Add `main` for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ lint-system-tests: style
 		tests_system/lobster_report \
 		tests_system/lobster_trlc \
 		tests_system/lobster_cpp \
-		tests_system/lobster_gtest
+		tests_system/lobster_gtest \
+		tests_system/lobster_pkg
 
 lint-unit-tests: style
 	@PYTHONPATH=$(SYSTEM_PYTHONPATH) \

--- a/tests_system/lobster_cpptest/test_config_exceptions.py
+++ b/tests_system/lobster_cpptest/test_config_exceptions.py
@@ -1,3 +1,4 @@
+import unittest
 from lobster.tools.cpptest.cpptest import (CODEBEAMER_URL, KIND,
                                            OUTPUT_FILE, SUPPORTED_KINDS)
 from tests_system.lobster_cpptest.\
@@ -90,3 +91,7 @@ class ConfigParserExceptionsCpptestTest(LobsterCpptestSystemTestCaseBase):
         with self.assertRaises(LOBSTER_Exception) as ctx:
             self._test_runner.run_tool_test()
         self.assertIn("Invalid config file", ctx.exception.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_cpptest/test_directories.py
+++ b/tests_system/lobster_cpptest/test_directories.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import shutil
+import unittest
 
 from tests_system.lobster_cpptest.\
     lobster_cpptest_system_test_case_base import LobsterCpptestSystemTestCaseBase
@@ -141,3 +142,7 @@ class DirectoriesCpptestTest(LobsterCpptestSystemTestCaseBase):
         asserter.assertStdErrText(
             'lobster-cpptest: "[\'.\']" does not contain any test file.\n')
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_cpptest/test_extension.py
+++ b/tests_system/lobster_cpptest/test_extension.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import unittest
 from tests_system.lobster_cpptest.\
     lobster_cpptest_system_test_case_base import LobsterCpptestSystemTestCaseBase
 from tests_system.lobster_cpptest.\
@@ -88,3 +89,7 @@ class ExtensionCpptestTest(LobsterCpptestSystemTestCaseBase):
             'lobster-cpptest: "no_input_file.cpp" is not a file or directory.\n'
         )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_cpptest/test_multiple_files.py
+++ b/tests_system/lobster_cpptest/test_multiple_files.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import unittest
 from tests_system.lobster_cpptest.\
     lobster_cpptest_asserter import LobsterCppTestAsserter as Asserter
 from tests_system.lobster_cpptest.\
@@ -98,3 +99,7 @@ class MultipleFilesCpptestTest(LobsterCpptestSystemTestCaseBase):
             'lobster-cpptest: "no_input_file.cpp" is not a file or directory.\n'
         )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_cpptest/test_references.py
+++ b/tests_system/lobster_cpptest/test_references.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import unittest
 from tests_system.lobster_cpptest.\
     lobster_cpptest_system_test_case_base import LobsterCpptestSystemTestCaseBase
 from tests_system.lobster_cpptest.\
@@ -98,3 +99,7 @@ class ReferencesCpptestTest(LobsterCpptestSystemTestCaseBase):
         asserter.assertStdOutNumAndFile(13, OUT_FILE)
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_cpptest/test_valid_scenario.py
+++ b/tests_system/lobster_cpptest/test_valid_scenario.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import unittest
 from tests_system.lobster_cpptest.\
     lobster_cpptest_system_test_case_base import LobsterCpptestSystemTestCaseBase
 from tests_system.asserter import Asserter
@@ -40,3 +41,7 @@ class InputFileCpptestTest(LobsterCpptestSystemTestCaseBase):
         # asserter.assertStdOutNumAndFile(7, OUT_FILE)
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_input_not_file_not_directory.py
+++ b/tests_system/lobster_json/test_input_not_file_not_directory.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_json.\
     lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
 from tests_system.asserter import Asserter
@@ -47,3 +48,7 @@ class InputNotFileNotDirectoryTest(LobsterJsonSystemTestCaseBase):
             f"directory\n"
         )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_inputs_and_inputs_from_file.py
+++ b/tests_system/lobster_json/test_inputs_and_inputs_from_file.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import shutil
+import unittest
 from tests_system.lobster_json.lobsterjsonasserter import LobsterJsonAsserter
 from tests_system.lobster_json.\
     lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
@@ -108,3 +109,7 @@ class InputsAndInputsFromFileParameterTest(LobsterJsonSystemTestCaseBase):
         asserter.assertNoStdErrText()
         asserter.assertStdOutNumAndFile(18, out_file)
         asserter.assertExitCode(0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_justification_attribute.py
+++ b/tests_system/lobster_json/test_justification_attribute.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_json.\
     lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
 from tests_system.lobster_json.lobsterjsonasserter import LobsterJsonAsserter
@@ -57,3 +58,7 @@ class JsonJustificationAttributeTest(LobsterJsonSystemTestCaseBase):
         asserter.assertStdOutNumAndFile(7, out_file)
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_multiple_files.py
+++ b/tests_system/lobster_json/test_multiple_files.py
@@ -1,4 +1,5 @@
 import shutil
+import unittest
 from tests_system.lobster_json.\
     lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
 from tests_system.lobster_json.lobsterjsonasserter import LobsterJsonAsserter
@@ -121,3 +122,7 @@ class JsonMultipleFilesTest(LobsterJsonSystemTestCaseBase):
         asserter.assertStdOutNumAndFile(13, out_file)
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_name_attribute.py
+++ b/tests_system/lobster_json/test_name_attribute.py
@@ -1,5 +1,6 @@
 from os import makedirs
 import shutil
+import unittest
 from tests_system.lobster_json.\
     lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
 from tests_system.lobster_json.lobsterjsonasserter import LobsterJsonAsserter
@@ -77,3 +78,7 @@ class JsonExtensionTest(LobsterJsonSystemTestCaseBase):
         asserter.assertStdOutNumAndFile(6, out_file)
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_tag_attribute.py
+++ b/tests_system/lobster_json/test_tag_attribute.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_json.\
     lobsterjsonsystemtestcasebase import LobsterJsonSystemTestCaseBase
 from tests_system.lobster_json.lobsterjsonasserter import LobsterJsonAsserter
@@ -47,3 +48,7 @@ class JsonTagAttributeTest(LobsterJsonSystemTestCaseBase):
             completed_process.returncode,
             "Required mandatory parameters missing - tag_attribute",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_json/test_valid_input.py
+++ b/tests_system/lobster_json/test_valid_input.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_json.lobsterjsonsystemtestcasebase import (
     LobsterJsonSystemTestCaseBase
@@ -30,3 +31,7 @@ class ValidInputTest(LobsterJsonSystemTestCaseBase):
         )
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_meta_data_tool_base/test_meta_data_tool_base.py
+++ b/tests_system/lobster_meta_data_tool_base/test_meta_data_tool_base.py
@@ -2,6 +2,7 @@ import os
 from tempfile import NamedTemporaryFile
 from dataclasses import dataclass
 from typing import Tuple, Type
+import unittest
 from tests_system.lobster_meta_data_tool_base.\
     lobster_meta_data_tool_base_system_test_case_base import (
         LobsterMetaDataToolBaseSystemTestCaseBase
@@ -109,3 +110,7 @@ class ToolBaseTest(LobsterMetaDataToolBaseSystemTestCaseBase):
             asserter.assert_result()
         finally:
             os.remove(tmp_file_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_online_report/test_config_exceptions.py
+++ b/tests_system/lobster_online_report/test_config_exceptions.py
@@ -1,3 +1,4 @@
+import unittest
 from lobster.tools.core.online_report.online_report import (
     REPO_ROOT, BASE_URL, COMMIT_ID)
 from tests_system.lobster_online_report.lobster_online_report_system_test_case_base \
@@ -55,3 +56,7 @@ class ConfigParserExceptionsOnlineReport(LobsterOnlineReportSystemTestCaseBase):
                 asserter = Asserter(self, completed_process, self._test_runner)
                 asserter.assertInStdErr(expected_error)
                 asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_online_report/test_valid_cases.py
+++ b/tests_system/lobster_online_report/test_valid_cases.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import unittest
 from unittest.mock import patch, Mock
 
 from lobster.common.report import Report
@@ -139,3 +140,7 @@ class ConfigParserExceptionsOnlineReport(LobsterOnlineReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_online_report_nogit/test_nogit.py
+++ b/tests_system/lobster_online_report_nogit/test_nogit.py
@@ -1,5 +1,6 @@
 import json
 import re
+import unittest
 from tests_system.lobster_online_report_nogit.\
     lobster_online_report_nogit_system_test_case_base import (
         LobsterOnlineReportNogitSystemTestCaseBase
@@ -155,3 +156,7 @@ class OnlineReportNogitTest(LobsterOnlineReportNogitSystemTestCaseBase):
         )
         asserter.assertNoStdOutText()
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_pkg/test_invalid_scenario.py
+++ b/tests_system/lobster_pkg/test_invalid_scenario.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_pkg.lobster_pkg_asserter import LobsterPkgAsserter
 from tests_system.lobster_pkg.lobster_pkg_system_test_case_base import (
     LobsterPKGSystemTestCaseBase)
@@ -118,3 +119,7 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
 
         asserter.assertExitCode(2)
         asserter.assertInStdErr("the following arguments are required: --out")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_pkg/test_valid_scenario.py
+++ b/tests_system/lobster_pkg/test_valid_scenario.py
@@ -1,8 +1,9 @@
+from pathlib import Path
+import shutil
+import unittest
 from tests_system.lobster_pkg.lobster_pkg_asserter import LobsterPkgAsserter
 from tests_system.lobster_pkg.lobster_pkg_system_test_case_base import (
     LobsterPKGSystemTestCaseBase)
-from pathlib import Path
-import shutil
 
 
 class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
@@ -220,3 +221,7 @@ class InputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertStdOutNumAndFile(1, OUT_FILE)
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_items_coverage.py
+++ b/tests_system/lobster_report/test_items_coverage.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase)
@@ -56,3 +57,7 @@ class ReportItemsCoverageTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_json_scanario.py
+++ b/tests_system/lobster_report/test_json_scanario.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase)
@@ -76,3 +77,7 @@ class ReportInvalidJsonTest(LobsterReportSystemTestCaseBase):
                                   "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_justification.py
+++ b/tests_system/lobster_report/test_justification.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase
@@ -40,3 +41,7 @@ class ReportJustificationTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_multiple_inputs.py
+++ b/tests_system/lobster_report/test_multiple_inputs.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase,
@@ -114,3 +115,7 @@ class ReportMultipleInputTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_multiple_traces.py
+++ b/tests_system/lobster_report/test_multiple_traces.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase,
@@ -39,3 +40,7 @@ class ReportMultipleTracesTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_resolve_references_errors.py
+++ b/tests_system/lobster_report/test_resolve_references_errors.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase)
@@ -67,3 +68,7 @@ class ReportResolveReferencesErrorsTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_schema_and_version.py
+++ b/tests_system/lobster_report/test_schema_and_version.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase)
@@ -85,3 +86,7 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
                                   "lobster-report: aborting due "
                                   "to earlier errors.\n")
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_tracing_policies.py
+++ b/tests_system/lobster_report/test_tracing_policies.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase,
@@ -98,3 +99,7 @@ class ReportTracingPoliciesTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_report/test_tracing_status.py
+++ b/tests_system/lobster_report/test_tracing_status.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_report.lobster_report_system_test_case_base import (
     LobsterReportSystemTestCaseBase,
@@ -104,3 +105,7 @@ class ReportTracingStatusTest(LobsterReportSystemTestCaseBase):
         asserter.assertNoStdOutText()
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_conversion.py
+++ b/tests_system/lobster_trlc/test_conversion.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from dataclasses import dataclass
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -121,3 +122,7 @@ class ConversionRuleTest(LobsterTrlcSystemTestCaseBase):
         )
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_conversion_errors.py
+++ b/tests_system/lobster_trlc/test_conversion_errors.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.asserter import Asserter
 from tests_system.lobster_trlc.lobster_system_test_case_base import \
     LobsterTrlcSystemTestCaseBase
@@ -137,3 +138,7 @@ class ConversionRuleErrorTest(LobsterTrlcSystemTestCaseBase):
             "symbol table: buildings.Does_Not_Exist.",
         )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_input_invalid_extensions.py
+++ b/tests_system/lobster_trlc/test_input_invalid_extensions.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -39,3 +40,7 @@ class TrlcInvalidExtensionsTest(LobsterTrlcSystemTestCaseBase):
             "extension. Expected one of .rsl, .trlc.\n"
         )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_input_list_of_files.py
+++ b/tests_system/lobster_trlc/test_input_list_of_files.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -78,3 +79,7 @@ class CmdArgsInputTest(LobsterTrlcSystemTestCaseBase):
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_inputs_and_inputs_from_file.py
+++ b/tests_system/lobster_trlc/test_inputs_and_inputs_from_file.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -53,3 +54,7 @@ class InputFromFilesAndInputsTest(LobsterTrlcSystemTestCaseBase):
                                   ' default_file.trlc:3\n'
                                   )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_inputs_from_directory.py
+++ b/tests_system/lobster_trlc/test_inputs_from_directory.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -42,3 +43,7 @@ class InputFromDirectory(LobsterTrlcSystemTestCaseBase):
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_inputs_from_file.py
+++ b/tests_system/lobster_trlc/test_inputs_from_file.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -49,3 +50,7 @@ class InputFromFilesTest(LobsterTrlcSystemTestCaseBase):
                                   ' default_file.trlc:3\n'
                                   )
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_inputs_zero.py
+++ b/tests_system/lobster_trlc/test_inputs_zero.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -75,3 +76,7 @@ class ZeroInputTest(LobsterTrlcSystemTestCaseBase):
         )
         asserter.assertNoStdOutText()
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_invalid_config.py
+++ b/tests_system/lobster_trlc/test_invalid_config.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -75,3 +76,7 @@ class MissingConfigTest(LobsterTrlcSystemTestCaseBase):
                                 "[Errno 2] No such file or directory:",
                                 completed_process.stderr)
         asserter.assertExitCode(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_trlc/test_output_correctness.py
+++ b/tests_system/lobster_trlc/test_output_correctness.py
@@ -1,3 +1,4 @@
+import unittest
 from tests_system.lobster_trlc.lobster_system_test_case_base import (
     LobsterTrlcSystemTestCaseBase)
 from tests_system.asserter import Asserter
@@ -66,3 +67,7 @@ class OutputCorrectnessTest(LobsterTrlcSystemTestCaseBase):
         )
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a call to `unittest-main()` in the `__main__` block of
system tests.
When running tests with `python -m unittest discover` the unit
test framework executes all tests rgardless whether `main()` is
present.
But when using a `py_test` in Bazel this is no longer true. Tests
are only executed through `unittest.main()`. If this function is
not called, then `py_test` returns SUCCESS, but in reality no
test was executed.

Hence it is crucial to call `unittest.main()` to support Bazel's
`py_test`.

Here we update most of the system tests which do not need a modification
of their Bazel call.

Also include `lobster-pkg` system tests in the lint target.