### PR TITLE
lobster-python: add system test infra and cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### 1.0.3-dev
 
+* `lobster-python`:
+  - Added system test infrastructure and Bazel targets under `tests_system/lobster_python`.
+
 * API documentation
   - Created comprehensive API documentation using Sphinx for better user experience across all LOBSTER tools
   - Added detailed examples and configuration parameters for `lobster-codebeamer`,

--- a/tests_system/.gitignore
+++ b/tests_system/.gitignore
@@ -5,4 +5,5 @@
 !lobster_codebeamer/data/*.lobster
 !lobster_html_report/data/*.lobster
 !lobster_cpptest/data/*.lobster
+!lobster_python/data/*.lobster
 !lobster_html_report/data/*.html

--- a/tests_system/lobster_python/BUILD.bazel
+++ b/tests_system/lobster_python/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+# BUILD.bazel
+# gazelle:exclude __init__.py
+
+py_library(
+    name = "lobster_python",
+    srcs = [
+        "lobster_python_system_test_case_base.py",
+        "lobster_python_test_runner.py",
+        "lobster_python_asserter.py",
+    ],
+    data = [
+        "//tests_system/lobster_python/data:python_data_system",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//:lobster",
+        "//tests_system",
+    ],
+)
+
+py_test(
+    name = "test_multiple_identical_function_names",
+    srcs = ["test_multiple_identical_function_names.py"],
+    deps = [
+        ":lobster_python",
+        "//tests_system",
+    ],
+)
+
+py_test(
+    name = "test_valid_cases",
+    srcs = ["test_valid_cases.py"],
+    deps = [
+        ":lobster_python",
+        "//tests_system",
+    ],
+)

--- a/tests_system/lobster_python/data/BUILD.bazel
+++ b/tests_system/lobster_python/data/BUILD.bazel
@@ -1,0 +1,8 @@
+filegroup(
+    name = "python_data_system",
+    srcs = glob([
+        "*.py",
+        "*.lobster",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/tests_system/lobster_python/data/basic.lobster
+++ b/tests_system/lobster_python/data/basic.lobster
@@ -1,0 +1,60 @@
+{
+  "data": [
+    {
+      "tag": "python basic.trlc_reference",
+      "location": {
+        "kind": "file",
+        "file": "basic.py",
+        "line": 4,
+        "column": null
+      },
+      "name": "basic.trlc_reference",
+      "messages": [],
+      "just_up": [
+        "helper function"
+      ],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    },
+    {
+      "tag": "python basic.Example.helper_function",
+      "location": {
+        "kind": "file",
+        "file": "basic.py",
+        "line": 13,
+        "column": null
+      },
+      "name": "basic.Example.helper_function",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Method"
+    },
+    {
+      "tag": "python basic.Example.nor",
+      "location": {
+        "kind": "file",
+        "file": "basic.py",
+        "line": 17,
+        "column": null
+      },
+      "name": "basic.Example.nor",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "refs": [
+        "req example.req_nor"
+      ],
+      "language": "Python",
+      "kind": "Method"
+    }
+  ],
+  "generator": "lobster_python",
+  "schema": "lobster-imp-trace",
+  "version": 3
+}

--- a/tests_system/lobster_python/data/basic.py
+++ b/tests_system/lobster_python/data/basic.py
@@ -1,0 +1,22 @@
+import potatolib
+
+
+def trlc_reference(requirement):
+    # lobster-exclude: helper function
+    def decorator(obj):
+        return obj
+    return decorator
+
+
+class Example:
+    @trlc_reference(requirement="example.req_nor")
+    def helper_function(a, b):
+        # potato
+        return a or b
+
+    def nor(a, b):
+        # lobster-trace: example.req_nor
+        assert isinstance(a, bool)
+        assert isinstance(b, bool)
+
+        return not helper_function(a, b)

--- a/tests_system/lobster_python/data/multiple_identical_function_names.lobster
+++ b/tests_system/lobster_python/data/multiple_identical_function_names.lobster
@@ -1,0 +1,103 @@
+{
+  "data": [
+    {
+      "tag": "python multiple_identical_function_names.get_requirements",
+      "location": {
+        "kind": "file",
+        "file": "multiple_identical_function_names.py",
+        "line": 5,
+        "column": null
+      },
+      "name": "multiple_identical_function_names.get_requirements",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    },
+    {
+      "tag": "python multiple_identical_function_names.set_requirements",
+      "location": {
+        "kind": "file",
+        "file": "multiple_identical_function_names.py",
+        "line": 8,
+        "column": null
+      },
+      "name": "multiple_identical_function_names.set_requirements",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    },
+    {
+      "tag": "python multiple_identical_function_names.get_requirements-1",
+      "location": {
+        "kind": "file",
+        "file": "multiple_identical_function_names.py",
+        "line": 13,
+        "column": null
+      },
+      "name": "multiple_identical_function_names.get_requirements",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    },
+    {
+      "tag": "python multiple_identical_function_names.display_requirements",
+      "location": {
+        "kind": "file",
+        "file": "multiple_identical_function_names.py",
+        "line": 17,
+        "column": null
+      },
+      "name": "multiple_identical_function_names.display_requirements",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    },
+    {
+      "tag": "python multiple_identical_function_names.set_requirements-1",
+      "location": {
+        "kind": "file",
+        "file": "multiple_identical_function_names.py",
+        "line": 21,
+        "column": null
+      },
+      "name": "multiple_identical_function_names.set_requirements",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    },
+    {
+      "tag": "python multiple_identical_function_names.get_requirements-2",
+      "location": {
+        "kind": "file",
+        "file": "multiple_identical_function_names.py",
+        "line": 26,
+        "column": null
+      },
+      "name": "multiple_identical_function_names.get_requirements",
+      "messages": [],
+      "just_up": [],
+      "just_down": [],
+      "just_global": [],
+      "language": "Python",
+      "kind": "Function"
+    }
+  ],
+  "generator": "lobster_python",
+  "schema": "lobster-imp-trace",
+  "version": 3
+}

--- a/tests_system/lobster_python/data/multiple_identical_function_names.py
+++ b/tests_system/lobster_python/data/multiple_identical_function_names.py
@@ -1,0 +1,27 @@
+flag = False
+requirements_global = None
+
+if flag:
+    def get_requirements(requirements):
+        return requirements
+else:
+    def set_requirements(requirements):
+        requirements_global = requirements
+        return requirements_global
+
+
+def get_requirements(requirements):
+    return requirements
+
+
+def display_requirements():
+    print(get_requirements())
+
+
+def set_requirements(requirements):
+    requirements_global = requirements
+    return requirements_global
+
+
+def get_requirements(requirements):
+    return requirements

--- a/tests_system/lobster_python/lobster_python_asserter.py
+++ b/tests_system/lobster_python/lobster_python_asserter.py
@@ -1,0 +1,14 @@
+from tests_system.asserter import Asserter
+
+
+# Setting this flag will tell unittest not to print tracebacks from this frame.
+# This way our custom assertions will show the interesting line number from the caller
+# frame, and not from this boring file.
+__unittest = True
+
+
+class LobsterPythonTestAsserter(Asserter):
+    def assertStdOutNumAndFile(self, num_items: int, out_file: str):
+        self.assertStdOutText(
+            f"Written output for {num_items} items to {out_file}\n"
+        )

--- a/tests_system/lobster_python/lobster_python_system_test_case_base.py
+++ b/tests_system/lobster_python/lobster_python_system_test_case_base.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from tests_system.lobster_python.lobster_python_test_runner import (
+    LobsterPythonTestRunner,
+)
+from tests_system.system_test_case_base import SystemTestCaseBase
+
+
+class LobsterPythonSystemTestCaseBase(SystemTestCaseBase):
+    def __init__(self, methodName):
+        super().__init__(methodName)
+        self._data_directory = Path(__file__).parents[0] / "data"
+
+    def create_test_runner(self) -> LobsterPythonTestRunner:
+        tool_name = Path(__file__).parents[0].name
+        test_runner = LobsterPythonTestRunner(
+            self.create_temp_dir(prefix=f"test-{tool_name}-"),
+        )
+        return test_runner

--- a/tests_system/lobster_python/lobster_python_test_runner.py
+++ b/tests_system/lobster_python/lobster_python_test_runner.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+from tests_system.testrunner import TestRunner
+from lobster.tools.python.python import main
+
+
+@dataclass
+class CmdArgs:
+    files: List[str]
+    out: Optional[str] = None
+    activity: bool = False
+    single: bool = False
+    only_tagged_functions: bool = False
+    parse_decorator: Optional[List[str]] = None
+    parse_versioned_decorator: Optional[List[str]] = None
+
+    def as_list(self) -> List[str]:
+        """Returns the command line arguments as a list for lobster-python"""
+        cmd_args: List[str] = []
+
+        if self.activity:
+            cmd_args.append("--activity")
+        if self.single:
+            cmd_args.append("--single")
+        if self.only_tagged_functions:
+            cmd_args.append("--only-tagged-functions")
+        if self.out is not None:
+            cmd_args.append(f"--out={self.out}")
+        if self.parse_decorator is not None:
+            # Expect two elements: decorator and name_arg
+            if len(self.parse_decorator) == 2:
+                cmd_args.extend([
+                    "--parse-decorator",
+                    *self.parse_decorator,
+                ])
+        if self.parse_versioned_decorator is not None:
+            # Expect three elements: decorator, name_arg, version_arg
+            if len(self.parse_versioned_decorator) == 3:
+                cmd_args.extend([
+                    "--parse-versioned-decorator",
+                    *self.parse_versioned_decorator,
+                ])
+
+        # Positional file/dir arguments come last
+        if self.files:
+            cmd_args.extend(self.files)
+
+        return cmd_args
+
+
+class LobsterPythonTestRunner(TestRunner):
+    """System test runner for lobster-python"""
+
+    def __init__(self, working_dir: Path):
+        super().__init__(main, working_dir)
+        self._cmd_args = CmdArgs(files=[])
+
+    @property
+    def cmd_args(self) -> CmdArgs:
+        return self._cmd_args
+
+    def get_tool_args(self) -> List[str]:
+        """Returns the command line arguments for 'lobster-python'"""
+        return self._cmd_args.as_list()

--- a/tests_system/lobster_python/test_multiple_identical_function_names.py
+++ b/tests_system/lobster_python/test_multiple_identical_function_names.py
@@ -1,0 +1,37 @@
+import unittest
+
+from tests_system.asserter import Asserter
+from tests_system.lobster_python.lobster_python_system_test_case_base import (
+    LobsterPythonSystemTestCaseBase,
+)
+from tests_system.lobster_python.\
+    lobster_python_asserter import LobsterPythonTestAsserter as Asserter
+
+
+class MultipleIdenticalFunctionNamesPython(LobsterPythonSystemTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self._test_runner = self.create_test_runner()
+
+    def test_multiple_identical_function_names(self):
+        OUT_FILE = "multiple_identical_function_names.lobster"
+        self._test_runner.declare_input_file(
+            self._data_directory / "multiple_identical_function_names.py"
+        )
+
+        self._test_runner.cmd_args.files = ["multiple_identical_function_names.py"]
+        self._test_runner.cmd_args.single = True
+        self._test_runner.cmd_args.out = OUT_FILE
+
+        self._test_runner.declare_output_file(self._data_directory / OUT_FILE)
+
+        completed_process = self._test_runner.run_tool_test()
+        asserter = Asserter(self, completed_process, self._test_runner)
+        asserter.assertNoStdErrText()
+        asserter.assertStdOutNumAndFile(6, OUT_FILE)
+        asserter.assertExitCode(0)
+        asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_system/lobster_python/test_valid_cases.py
+++ b/tests_system/lobster_python/test_valid_cases.py
@@ -1,0 +1,37 @@
+import unittest
+
+from tests_system.asserter import Asserter
+from tests_system.lobster_python.lobster_python_system_test_case_base import (
+    LobsterPythonSystemTestCaseBase,
+)
+from tests_system.lobster_python.\
+    lobster_python_asserter import LobsterPythonTestAsserter as Asserter
+
+
+class ValidCasesPython(LobsterPythonSystemTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self._test_runner = self.create_test_runner()
+
+    def test_valid_python(self):
+        """Simple Python file and verifies the generated lobster output."""
+        OUT_FILE = "basic.lobster"
+
+        self._test_runner.declare_input_file(self._data_directory / "basic.py")
+
+        self._test_runner.cmd_args.files = ["basic.py"]
+        self._test_runner.cmd_args.single = True
+        self._test_runner.cmd_args.out = OUT_FILE
+
+        self._test_runner.declare_output_file(self._data_directory / OUT_FILE)
+
+        completed_process = self._test_runner.run_tool_test()
+        asserter = Asserter(self, completed_process, self._test_runner)
+        asserter.assertNoStdErrText()
+        asserter.assertStdOutNumAndFile(3, OUT_FILE)
+        asserter.assertExitCode(0)
+        asserter.assertOutputFiles()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add runner, base, Bazel targets, tests, and data fixtures for lobster-python system tests, aligning with existing tool infra.
