### PR TITLE
Automatically create output directories for all LOBSTER tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ### 1.0.3-dev
 
+* All tools now automatically create output directories if they don't exist.
+  Previously, tools would crash with an exception if the specified output
+  directory path did not exist. This enhancement improves usability and
+  prevents unexpected failures when working with nested directory structures.
+
 * `lobster-codebeamer`:
   - Improved error messages with detailed troubleshooting information:
     - Connection timeout errors now include the URL and suggest increasing timeout parameter

--- a/lobster/common/io.py
+++ b/lobster/common/io.py
@@ -17,6 +17,7 @@
 # License along with this program. If not, see
 # <https://www.gnu.org/licenses/>.
 
+import os
 import json
 from typing import Dict, Optional, Sequence, TextIO, Type, Union, Iterable
 
@@ -145,3 +146,10 @@ def signal_duplicate_items(
                         f"{items[item.tag.key()].location.to_string()}",
                 fatal=(counter == len(duplicate_items)),
             )
+
+
+def ensure_output_directory(file_path: str) -> None:
+    """Create parent directories for the output file if they don't exist."""
+    output_dir = os.path.dirname(file_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)

--- a/lobster/common/multi_file_input_tool.py
+++ b/lobster/common/multi_file_input_tool.py
@@ -21,7 +21,7 @@ from abc import ABCMeta
 from typing import Iterable, List, Optional, Type, Union
 from lobster.common.errors import Message_Handler
 from lobster.common.items import Requirement, Implementation, Activity
-from lobster.common.io import lobster_write
+from lobster.common.io import lobster_write, ensure_output_directory
 from lobster.common.meta_data_tool_base import MetaDataToolBase
 from lobster.common.multi_file_input_config import Config
 from lobster.common.file_collector import FileCollector
@@ -132,6 +132,7 @@ class MultiFileInputTool(MetaDataToolBase, metaclass=ABCMeta):
             out_file: str,
             items: List[Union[Activity, Implementation, Requirement]],
     ):
+        ensure_output_directory(out_file)
         with open(out_file, "w", encoding="UTF-8") as fd:
             lobster_write(fd, schema, self.name, items)
         print(f"{self.name}: wrote {len(items)} items to {out_file}")

--- a/lobster/common/report.py
+++ b/lobster/common/report.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with this program. If not, see
 # <https://www.gnu.org/licenses/>.
-
 import json
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -25,7 +24,7 @@ from lobster.common.level_definition import LevelDefinition
 from lobster.common.items import Tracing_Status, Requirement, Implementation, Activity
 from lobster.common.parser import load as load_config
 from lobster.common.errors import Message_Handler
-from lobster.common.io import lobster_read
+from lobster.common.io import lobster_read, ensure_output_directory
 from lobster.common.location import File_Reference
 
 
@@ -141,6 +140,7 @@ class Report:
             "matrix"    : [],
         }
 
+        ensure_output_directory(filename)
         with open(filename, "w", encoding="UTF-8") as fd:
             json.dump(report, fd, indent=2)
             fd.write("\n")

--- a/lobster/common/tool.py
+++ b/lobster/common/tool.py
@@ -29,7 +29,7 @@ import yaml
 from lobster.common.errors import Message_Handler
 from lobster.common.location import File_Reference
 from lobster.common.items import Requirement, Implementation, Activity
-from lobster.common.io import lobster_write
+from lobster.common.io import lobster_write, ensure_output_directory
 from lobster.common.meta_data_tool_base import MetaDataToolBase
 
 
@@ -262,6 +262,7 @@ class LOBSTER_Tool(MetaDataToolBase, SupportedCommonConfigKeys, metaclass=ABCMet
                    for item in items)
 
         if options.out:
+            ensure_output_directory(options.out)
             with open(options.out, "w", encoding="UTF-8") as fd:
                 lobster_write(fd, self.schema, self.name, items)
             print(f"{self.name}: wrote {len(items)} items to {options.out}")

--- a/lobster/tools/codebeamer/codebeamer.py
+++ b/lobster/tools/codebeamer/codebeamer.py
@@ -54,7 +54,7 @@ from urllib3.util.retry import Retry
 from lobster.common.items import Tracing_Tag, Requirement, Implementation, Activity
 from lobster.common.location import Codebeamer_Reference
 from lobster.common.errors import Message_Handler, LOBSTER_Error
-from lobster.common.io import lobster_read, lobster_write
+from lobster.common.io import lobster_read, lobster_write, ensure_output_directory
 from lobster.common.meta_data_tool_base import MetaDataToolBase
 from lobster.tools.codebeamer.bearer_auth import BearerAuth
 from lobster.tools.codebeamer.config import AuthenticationConfig, Config
@@ -657,6 +657,7 @@ class CodebeamerTool(MetaDataToolBase):
 
 def _get_out_stream(config_out: Optional[str]) -> TextIO:
     if config_out:
+        ensure_output_directory(config_out)
         return open(config_out, "w", encoding="UTF-8")
     return sys.stdout
 
@@ -672,6 +673,7 @@ def lobster_codebeamer(config: Config, out_file: str) -> None:
     """
     # This is an API function.
     items = get_query(config, config.import_query)
+    ensure_output_directory(out_file)
     with open(out_file, "w", encoding="UTF-8") as fd:
         _cb_items_to_lobster(items, config, fd)
 

--- a/lobster/tools/core/html_report/html_report.py
+++ b/lobster/tools/core/html_report/html_report.py
@@ -30,6 +30,7 @@ import markdown
 from lobster.common.version import LOBSTER_VERSION
 from lobster.htmldoc import htmldoc
 from lobster.common.report import Report
+from lobster.common.io import ensure_output_directory
 from lobster.common.location import (Void_Reference,
                                      File_Reference,
                                      Github_Reference,
@@ -284,6 +285,14 @@ def generate_custom_data(report) -> str:
         if value
     ]
     return "".join(content)
+
+
+def write_html_to_file(html_content: str, output_path: str) -> None:
+    """Write HTML content to file, creating parent directories if needed."""
+    ensure_output_directory(output_path)
+    with open(output_path, "w", encoding="UTF-8") as fd:
+        fd.write(html_content)
+        fd.write("\n")
 
 
 def write_html(report, dot, high_contrast, render_md) -> str:
@@ -613,9 +622,7 @@ class HtmlReportTool(MetaDataToolBase):
             high_contrast = options.high_contrast,
             render_md = options.render_md,
         )
-        with open(options.out, "w", encoding="UTF-8") as fd:
-            fd.write(html_content)
-            fd.write("\n")
+        write_html_to_file(html_content, options.out)
         print(f"LOBSTER HTML report written to {options.out}")
 
         return 0
@@ -646,9 +653,7 @@ def lobster_html_report(
         high_contrast=high_contrast,
         render_md=render_md,
     )
-    with open(output_html_path, "w", encoding="UTF-8") as fd:
-        fd.write(html_content)
-        fd.write("\n")
+    write_html_to_file(html_content, output_html_path)
 
 
 def main(args: Optional[Sequence[str]] = None) -> int:

--- a/lobster/tools/cpptest/cpptest.py
+++ b/lobster/tools/cpptest/cpptest.py
@@ -19,7 +19,7 @@
 
 import sys
 from argparse import Namespace
-import os.path
+import os
 from copy import copy
 from dataclasses import dataclass, field
 from typing import List, Optional, Sequence, Union
@@ -29,7 +29,7 @@ from lobster.common.errors import LOBSTER_Error
 from lobster.common.exceptions import LOBSTER_Exception
 from lobster.common.items import Tracing_Tag, Activity
 from lobster.common.location import File_Reference
-from lobster.common.io import lobster_write
+from lobster.common.io import lobster_write, ensure_output_directory
 from lobster.common.file_tag_generator import FileTagGenerator
 from lobster.tools.cpptest.constants import Constants
 from lobster.tools.cpptest.requirements_parser import \
@@ -303,16 +303,16 @@ def write_lobster_items_output_dict(lobster_items_output_dict: dict):
         lobster_items_dict.update(orphan_test_items)
         item_count = len(lobster_items_dict)
 
-        if output_file_name:
-            with open(output_file_name, "w", encoding="UTF-8") as output_file:
-                lobster_write(
-                    output_file,
-                    Activity,
-                    lobster_generator,
-                    lobster_items_dict.values()
-                )
-            print(f'Written {item_count} lobster items to '
-                  f'"{output_file_name}".')
+        ensure_output_directory(output_file_name)
+        with open(output_file_name, "w", encoding="UTF-8") as output_file:
+            lobster_write(
+                output_file,
+                Activity,
+                lobster_generator,
+                lobster_items_dict.values()
+            )
+        print(f'Written {item_count} lobster items to '
+                f'"{output_file_name}".')
 
 
 def run_lobster_cpptest(config: Config):

--- a/lobster/tools/gtest/gtest.py
+++ b/lobster/tools/gtest/gtest.py
@@ -19,13 +19,13 @@
 
 from argparse import Namespace
 import sys
-import os.path
+import os
 from typing import Optional, Sequence
 import xml.etree.ElementTree as ET
 
 from lobster.common.items import Tracing_Tag, Activity
 from lobster.common.location import Void_Reference, File_Reference
-from lobster.common.io import lobster_write
+from lobster.common.io import lobster_write, ensure_output_directory
 from lobster.common.meta_data_tool_base import MetaDataToolBase
 
 
@@ -141,6 +141,7 @@ class GtestTool(MetaDataToolBase):
                     items.append(item)
 
         if options.out:
+            ensure_output_directory(options.out)
             with open(options.out, "w", encoding="UTF-8") as fd:
                 lobster_write(fd, Activity, "lobster_gtest", items)
             print(f"Written output for {len(items)} items to {options.out}")

--- a/lobster/tools/python/python.py
+++ b/lobster/tools/python/python.py
@@ -30,7 +30,7 @@ import libcst as cst
 
 from lobster.common.items import Tracing_Tag, Implementation, Activity
 from lobster.common.location import File_Reference
-from lobster.common.io import lobster_write
+from lobster.common.io import lobster_write, ensure_output_directory
 from lobster.common.meta_data_tool_base import MetaDataToolBase
 
 LOBSTER_TRACE_PREFIX = "# lobster-trace: "
@@ -534,6 +534,7 @@ class PythonTool(MetaDataToolBase):
             schema = Implementation
 
         if options.out:
+            ensure_output_directory(options.out)
             with open(options.out, "w", encoding="UTF-8") as fd:
                 lobster_write(fd, schema, "lobster_python", items)
             print(f"Written output for {len(items)} items to {options.out}")

--- a/lobster/tools/trlc/trlc_tool.py
+++ b/lobster/tools/trlc/trlc_tool.py
@@ -28,7 +28,6 @@ from trlc.errors import Message_Handler, TRLC_Error
 from trlc.trlc import Source_Manager
 
 from lobster.common.errors import PathError
-from lobster.common.io import lobster_write
 from lobster.common.items import Requirement
 from lobster.common.multi_file_input_tool import create_worklist, MultiFileInputTool
 
@@ -131,15 +130,8 @@ class LOBSTER_Trlc(MultiFileInputTool):
             if item:
                 items.append(item)
 
-        with open(options.out, "w", encoding="UTF-8") as fd:
-            # lobster-trace: trlc_req.Output_File
-            lobster_write(
-                fd=fd,
-                kind=Requirement,
-                generator="lobster-trlc",
-                items=items,
-            )
-        print(f"lobster-trlc: successfully wrote {len(items)} items to {options.out}")
+        # lobster-trace: trlc_req.Output_File
+        self._write_output(Requirement, options.out, items)
 
 
 def main(args: Optional[Sequence[str]] = None) -> int:

--- a/tests_system/asserter.py
+++ b/tests_system/asserter.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest import TestCase
 from tests_system.testrunner import TestRunner, TestRunResult
 
@@ -77,7 +78,13 @@ class Asserter:
             )
 
         for expected_file_ref in self._test_runner.tool_output_files:
-            expected_location = self._test_runner.working_dir / expected_file_ref.name
+            # Accept both str and Path for expected_file_ref
+            if isinstance(expected_file_ref, str):
+                expected_file_ref_path = Path(expected_file_ref)
+            else:
+                expected_file_ref_path = expected_file_ref
+            expected_location = (self._test_runner.working_dir /
+                                 expected_file_ref_path.name)
             try:
                 with open(
                     expected_file_ref,

--- a/tests_system/lobster_pkg/test_invalid_scenario.py
+++ b/tests_system/lobster_pkg/test_invalid_scenario.py
@@ -37,19 +37,22 @@ class InvalidInputFilePkgTest(LobsterPKGSystemTestCaseBase):
         asserter.assertExitCode(1)
 
     def test_not_existing_output_path(self):
-        """Test that a missing output path causes non-zero exit code"""
-        # lobster-trace: UseCases.PKG_Files_Missing
-        OUT_FILE = "not_existing/not_existing.lobster"
+        """Test that a missing output path is created automatically"""
+        OUT_FILE = str(self._data_directory / "not_existing/not_existing.lobster")
+        self._test_runner.declare_input_file(self._data_directory / "valid_file1.pkg")
         self._test_runner.cmd_args.files = [
             str(self._data_directory / "valid_file1.pkg")
         ]
 
         self._test_runner.cmd_args.out = OUT_FILE
-
         completed_process = self._test_runner.run_tool_test()
+
+        self._test_runner.declare_output_file(OUT_FILE)
+
         asserter = LobsterPkgAsserter(self, completed_process, self._test_runner)
-        asserter.assertInStdErr(f'No such file or directory: \'{OUT_FILE}\'')
-        asserter.assertExitCode(1)
+        asserter.assertNoStdErrText()
+        asserter.assertStdOutNumAndFile(1, OUT_FILE)
+        asserter.assertExitCode(0)
 
     def test_misplaced_lobster_trace_file(self):
         """Test that a misplaced lobster-trace in ANALYSISITEM causes a warning

--- a/tests_system/lobster_trlc/test_conversion.py
+++ b/tests_system/lobster_trlc/test_conversion.py
@@ -76,7 +76,7 @@ class ConversionRuleTest(LobsterTrlcSystemTestCaseBase):
                 asserter = Asserter(self, completed_process, test_runner)
                 asserter.assertNoStdErrText()
                 asserter.assertStdOutText(
-                    f"lobster-trlc: successfully wrote {setup.num_expected_items} "
+                    f"lobster-trlc: wrote {setup.num_expected_items} "
                     f"items to {out_file}\n",
                 )
                 asserter.assertExitCode(0)
@@ -120,7 +120,7 @@ class ConversionRuleTest(LobsterTrlcSystemTestCaseBase):
         asserter = Asserter(self, completed_process, test_runner)
         asserter.assertNoStdErrText()
         asserter.assertStdOutText(
-            f"lobster-trlc: successfully wrote 4 items to {out_file}\n",
+            f"lobster-trlc: wrote 4 items to {out_file}\n",
         )
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
@@ -170,7 +170,7 @@ class ConversionRuleTest(LobsterTrlcSystemTestCaseBase):
                 asserter = Asserter(self, completed_process, test_runner)
                 asserter.assertNoStdErrText()
                 asserter.assertStdOutText(
-                    f"lobster-trlc: successfully wrote {setup.num_expected_items} "
+                    f"lobster-trlc: wrote {setup.num_expected_items} "
                     f"items to {out_file}\n",
                 )
                 asserter.assertExitCode(0)

--- a/tests_system/lobster_trlc/test_input_list_of_files.py
+++ b/tests_system/lobster_trlc/test_input_list_of_files.py
@@ -23,7 +23,7 @@ class InputListOfFilesTest(LobsterTrlcSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 1 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 1 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
@@ -75,7 +75,7 @@ class CmdArgsInputTest(LobsterTrlcSystemTestCaseBase):
         completed_process = test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 1 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 1 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()

--- a/tests_system/lobster_trlc/test_inputs_and_inputs_from_file.py
+++ b/tests_system/lobster_trlc/test_inputs_and_inputs_from_file.py
@@ -44,7 +44,7 @@ class InputFromFilesAndInputsTest(LobsterTrlcSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 2 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 2 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()

--- a/tests_system/lobster_trlc/test_inputs_from_directory.py
+++ b/tests_system/lobster_trlc/test_inputs_from_directory.py
@@ -39,7 +39,7 @@ class InputFromDirectory(LobsterTrlcSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 3 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 3 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()

--- a/tests_system/lobster_trlc/test_inputs_from_file.py
+++ b/tests_system/lobster_trlc/test_inputs_from_file.py
@@ -24,7 +24,7 @@ class InputFromFilesTest(LobsterTrlcSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 1 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 1 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()

--- a/tests_system/lobster_trlc/test_inputs_zero.py
+++ b/tests_system/lobster_trlc/test_inputs_zero.py
@@ -26,7 +26,7 @@ class ZeroInputTest(LobsterTrlcSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 0 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 0 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
         asserter.assertOutputFiles()
@@ -48,7 +48,7 @@ class ZeroInputTest(LobsterTrlcSystemTestCaseBase):
         completed_process = self._test_runner.run_tool_test()
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
-        asserter.assertStdOutText(f"lobster-trlc: successfully wrote 0 items to "
+        asserter.assertStdOutText(f"lobster-trlc: wrote 0 items to "
                                   f"{OUT_FILE}\n")
         asserter.assertExitCode(0)
 

--- a/tests_system/lobster_trlc/test_output_correctness.py
+++ b/tests_system/lobster_trlc/test_output_correctness.py
@@ -62,7 +62,7 @@ class OutputCorrectnessTest(LobsterTrlcSystemTestCaseBase):
         asserter = Asserter(self, completed_process, self._test_runner)
         asserter.assertNoStdErrText()
         asserter.assertStdOutText(
-            "lobster-trlc: successfully wrote 5 items to "
+            "lobster-trlc: wrote 5 items to "
             "output_correctness_test.out.lobster\n",
         )
         asserter.assertExitCode(0)


### PR DESCRIPTION
Automatically create output directories for all LOBSTER tools to prevent crashes when paths don't exist
