### PR TITLE
Fix abstract-class-instantiated

### DIFF
--- a/tests_unit/pylint3.cfg
+++ b/tests_unit/pylint3.cfg
@@ -11,7 +11,6 @@ disable=
  too-many-locals,
  unused-argument,
  abstract-method,
- abstract-class-instantiated,
 
 [REPORTS]
 output-format=text

--- a/tests_unit/test_tool.py
+++ b/tests_unit/test_tool.py
@@ -1,3 +1,4 @@
+from typing import Set
 import unittest
 import os
 import argparse
@@ -16,6 +17,9 @@ class ConcreteLOBSTER_Tool(LOBSTER_Tool):
 
     def _run_impl(self, options: argparse.Namespace) -> int:
         return 0
+
+    def get_mandatory_parameters(self) -> Set[str]:
+        raise NotImplementedError("not implemented for testing")
 
 
 class TestLOBSTER_Tool(unittest.TestCase):


### PR DESCRIPTION
The class inheritance is as follows:
`ConcreteLOBSTER_Tool` -> `LOBSTER_Tool` -> (`MetaDataToolBase`, `SupportedCommonConfigKeys`)
and the implementation for abstract method `get_mandatory_parameters` was missing.

The implementation is not needed in the unit test, but adding it allows us to clean up the Pylint configuration.