### PR TITLE
Activate `no-else-return` check

### DIFF
--- a/pylint3.cfg
+++ b/pylint3.cfg
@@ -11,7 +11,6 @@ disable=
  too-many-locals,
  too-many-statements,
  too-many-nested-blocks,
- no-else-return,
  no-else-raise,
  no-else-break,
  no-else-continue,


### PR DESCRIPTION
Activate the check `no-else-return` in the Pylint configuration.

This PR can be merged once these are merged:
* https://github.com/bmw-software-engineering/lobster/pull/551
* https://github.com/bmw-software-engineering/lobster/pull/552
* https://github.com/bmw-software-engineering/lobster/pull/555
* https://github.com/bmw-software-engineering/lobster/pull/557