### PR TITLE
Remove disabled flags from pylint config

### DIFF
--- a/pylint3.cfg
+++ b/pylint3.cfg
@@ -11,9 +11,6 @@ disable=
  too-many-locals,
  too-many-statements,
  too-many-nested-blocks,
- no-else-raise,
- no-else-break,
- no-else-continue,
  consider-using-f-string
 
 [REPORTS]


### PR DESCRIPTION
Removed those flags from the `disable` section in the pylint configuration where pylint shows zero findings.