### PR TITLE
Fix typo and pylint issue

### DIFF
--- a/lobster/common/io.py
+++ b/lobster/common/io.py
@@ -80,7 +80,7 @@ def lobster_read(
 
     for rkey in ("schema", "version", "generator", "data"):
         if rkey not in data:
-            mh.error(loc, "required top-levelkey %s not present" % rkey)
+            mh.error(loc, "required top-level key %s not present" % rkey)
         if rkey == "data":
             if not isinstance(data[rkey], list):
                 mh.error(loc, "data is not an array")

--- a/lobster/common/report.py
+++ b/lobster/common/report.py
@@ -262,6 +262,6 @@ class Report:
                      dict: "an object"}
         for rkey, rvalue in rkey_dict.items():
             if rkey not in data:
-                self.mh.error(loc, "required top-levelkey %s not present" % rkey)
+                self.mh.error(loc, "required top-level key %s not present" % rkey)
             if not isinstance(data[rkey], rvalue):
                 self.mh.error(loc, "%s is not %s." % (rkey, type_dict[rvalue]))

--- a/tests_system/lobster_report/test_schema_and_version.py
+++ b/tests_system/lobster_report/test_schema_and_version.py
@@ -42,7 +42,7 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
         asserter = Asserter(self, result, self._test_runner)
         asserter.assertNoStdErrText()
         asserter.assertStdOutText("trlc_missing_schema.lobster: "
-                                  "lobster error: required top-levelkey "
+                                  "lobster error: required top-level key "
                                   "schema not present\n\n"
                                   "lobster-report: aborting due "
                                   "to earlier errors.\n")
@@ -81,7 +81,7 @@ class ReportSchemaAndVersionTest(LobsterReportSystemTestCaseBase):
         asserter = Asserter(self, result, self._test_runner)
         asserter.assertNoStdErrText()
         asserter.assertStdOutText("trlc_missing_version.lobster: "
-                                  "lobster error: required top-levelkey "
+                                  "lobster error: required top-level key "
                                   "version not present\n\n"
                                   "lobster-report: aborting due "
                                   "to earlier errors.\n")

--- a/tests_unit/pylint3.cfg
+++ b/tests_unit/pylint3.cfg
@@ -6,7 +6,6 @@ disable=
  duplicate-code,
  too-many-statements,
  protected-access,
- no-member,
  too-many-instance-attributes,
  too-many-locals,
  unused-argument,

--- a/tests_unit/test_io.py
+++ b/tests_unit/test_io.py
@@ -1,9 +1,8 @@
 import unittest
 import io
 import json
-from unittest.mock import patch, create_autospec, mock_open, ANY
+from unittest.mock import patch, create_autospec, mock_open
 from lobster.common.errors import Message_Handler, LOBSTER_Error
-from lobster.common.location import File_Reference
 from lobster.common.items import Tracing_Tag, Requirement, Implementation, Activity
 from lobster.common.io import lobster_write, lobster_read
 from lobster.common.location import Location
@@ -231,9 +230,9 @@ class LobsterWriteReadTests(unittest.TestCase):
         read_data='{"schema": "lobster-req-trace", "version": 4, "generator": "mock_generator"}',
     )
     def test_lobster_read_missing_data_key(self, mock_file_open, mock_isfile):
-        with self.assertRaises(LOBSTER_Error):
+        with self.assertRaises(LOBSTER_Error) as exc_info:
             lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
-            self.mh.error.assert_called_with(ANY, "required top-level key data not present")
+        self.assertIn("required top-level key data not present", exc_info.exception.message)
 
     @patch("os.path.isfile", return_value=True)
     @patch(
@@ -242,12 +241,12 @@ class LobsterWriteReadTests(unittest.TestCase):
         read_data='{"schema": "lobster-req-trace", "version": 5, "generator": "test_gen", "data": []}',
     )
     def test_lobster_read_unsupported_version(self, mock_file_open, mock_isfile):
-        with self.assertRaises(LOBSTER_Error):
+        with self.assertRaises(LOBSTER_Error) as exc_info:
             lobster_read(self.mh, self.filename, self.level, self.items, self.source_info)
-            self.mh.error.assert_called_with(
-                File_Reference(self.filename),
-                "version 5 for schema lobster-req-trace is not supported",
-            )
+        self.assertEqual(
+            exc_info.exception.message,
+            "version 5 for schema lobster-req-trace is not supported",
+        )
 
     @patch("os.path.isfile", return_value=True)
     @patch(


### PR DESCRIPTION
Fix a `no-member` issue in a unit test.
Fix a typo in an error message.