### PR TITLE
Include Python 3.14 in the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-14]
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-14
             brew: "/opt/homebrew"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-14]
-        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        py-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-14
             brew: "/opt/homebrew"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
   - Added detailed examples and configuration parameters for `lobster-codebeamer`,
   `lobster-cpptest`, `lobster-report`, `lobster-html_report`, and `lobster-online_report` tools
 
-* Included Python 3.13 in the CI test matrix.
+* Included Python 3.13 and 3.14 in the CI test matrix.
 
 ### 1.0.2
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 * Removed wrong statement from `schemas.md` regarding "status" field.
 
+* Included Python 3.13 and 3.14 in the CI test matrix.
+
 ### 1.0.6
 
 * Call Lobster Report via bazel directly instead of using a symlink


### PR DESCRIPTION
Note that [TRLC 2.0.4](https://github.com/bmw-software-engineering/trlc/releases/tag/trlc-2.0.4) has been released, which supports Python 3.14. So we can include Python 3.14 in the test matrix. Note that `lobster-trlc` depends on `trlc`.