### PR TITLE
Fix parallel coverage run for system and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,15 @@ jobs:
       - name: Executing unit tests
         run: |
           make unit-tests
+      - name: Unit tests coverage analysis
+        run: |
+          make coverage-unit
       - name: Executing system tests
         run: |
           make system-tests
-      - name: Coverage analysis
+      - name: System tests coverage analysis
         run: |
           make coverage-system
-          make coverage-unit
   integration-tests:
     name: Integration tests
     needs: [changes, lint-code, lint-system-tests, trlc]


### PR DESCRIPTION
**Problem:**

coverage combine consumes (deletes) parallel data files after combining them. When make coverage-system runs, it writes its combined output to the default [.coverage](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) file. If .coverage.unit* files overlap in discovery or the execution order is incorrect, subsequent make coverage-unit fails with:

"Couldn't combine from non-existent path '.coverage.unit*'"

This occurs because coverage 7.x auto-discovers parallel data files in the current directory, potentially consuming both .coverage.system* and .coverage.unit* files during a single combine operation. See [coverage 7.14.0 release notes](https://coverage.readthedocs.io/en/7.14.0/changes.html#version-7-14-0-2026-05-10).

**Fix:**

Ensure each test execution is immediately followed by its corresponding coverage report, so data files are consumed before the next test run produces new ones. This prevents cross-contamination between unit and system coverage data.