### PR TITLE
Automate Bazel Central Registry release workflow for tagged releases

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/bmw-software-engineering/lobster",
+    "maintainers": [
+        {
+            "email": "Rahul.Sutariya@bti.bmwgroup.com",
+            "github": "Rahul-Sutariya",
+            "name": "RAHUL SUTARIYA",
+            "github_user_id": 113970414
+        },
+        {
+            "email": "Ambuj.Singh@bti.bmwgroup.com",
+            "github": "AAmbuj",
+            "name": "Ambuj Singh Kushwaha",
+            "github_user_id": 73685939
+        }
+    ],
+    "repository": [
+        "github:bmw-software-engineering/lobster"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,39 @@
+incompatible_flags:
+  "--incompatible_config_setting_private_default_visibility":
+    - 8.x
+  "--incompatible_disable_starlark_host_transitions":
+    - 8.x
+  "--incompatible_disable_native_repo_rules":
+    - 8.x
+  "--incompatible_strict_action_env":
+    - 8.x
+
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+    - windows
+  bazel:
+    - 8.x
+  python_version:
+    - "3.9"
+    - "3.10"
+    - "3.11"
+    - "3.12"
+
+# Verify all lobster module entry points build correctly across all supported platforms and Python versions before release.
+tasks:
+  run_test_module:
+    name: "Verify lobster (Python ${{ python_version }})"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # ← explicit Python version
+    build_targets:
+      - "@lobster//:lobster"
+    test_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # ← explicit Python version
+    test_targets:
+      - "@lobster//tests_unit/..."
+      - "@lobster//tests_system/..."
+      - "@lobster//tests_integration/..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "**leave this alone**",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{TAG}.tar.gz"
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to BCR
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+      registry_fork:
+        required: false
+        type: string
+        default: bmw-software-engineering/bazel-central-registry
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Git tag being released
+        required: true
+        type: string
+      registry_fork:
+        description: GitHub fork used to open the BCR PR (owner/repo)
+        required: false
+        type: string
+        default: bmw-software-engineering/bazel-central-registry
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      registry_fork: ${{ inputs.registry_fork }}
+      draft: false
+      attest: true
+      tag_prefix: "lobster-"
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Git tag being released
+        required: true
+        type: string
+      registry_fork:
+        description: GitHub fork used to open the BCR PR (owner/repo)
+        required: false
+        type: string
+        default: bmw-software-engineering/bazel-central-registry
+  push:
+    tags:
+      - "lobster-*"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
+
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.6.0
+    with:
+      release_files: archives/*.*
+      prerelease: false
+      draft: false
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      bazel_test_command: "echo 'Tests skipped during release (run in CI workflow)'"
+      mount_bazel_caches: false
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    secrets: {}
+
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: ${{ inputs.registry_fork || 'bmw-software-engineering/bazel-central-registry' }}
+    secrets: inherit

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+TAG="$1"
+
+if [[ "$TAG" == lobster-* ]]; then
+  VERSION="${TAG#lobster-}"
+else
+  echo "ERROR: tag '${TAG}' does not match expected format 'lobster-X.Y.Z'" >&2
+  exit 1
+fi
+
+mkdir -p archives
+
+PREFIX="lobster-${VERSION}"
+ARCHIVE="archives/${TAG}.tar.gz"
+
+git archive --format=tar --prefix="${PREFIX}/" "$TAG" | gzip > "$ARCHIVE"
+
+SHA=$(sha256sum "$ARCHIVE" | awk '{print $1}')
+
+cat <<EOF
+## Bzlmod
+
+Add this to your MODULE.bazel:
+
+~~~starlark
+bazel_dep(name = "lobster", version = "${VERSION}")
+~~~
+
+## WORKSPACE
+
+~~~starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "lobster",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}",
+    urls = ["https://github.com/bmw-software-engineering/lobster/releases/download/${TAG}/${TAG}.tar.gz"],
+)
+~~~
+EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "lobster",
-    version = "0.13.2",
+    version = "1.0.3",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The individual PyPI packages that `bmw-lobster` depends on are:
 
 ### For LOBSTER developers
 
+* [Release Process](documentation/release.md)
 * [System Test Coverage Report](https://bmw-software-engineering.github.io/lobster/htmlcov-system/index.html)
 * [Unit Test Coverage Report](https://bmw-software-engineering.github.io/lobster/htmlcov-unit/index.html)
 * [LOBSTER API Documentation](https://bmw-software-engineering.github.io/lobster/api_documentation/)

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -1,0 +1,28 @@
+# Release Process
+
+## Automated BCR Release Flow
+
+BCR releases are fully automated via GitHub Actions. To trigger a release:
+
+1. Push a tag in the format `lobster-X.Y.Z`.
+2. `.github/workflows/release.yml` runs and:
+   - Calls `.github/workflows/release_prep.sh` to build a source archive under `archives/` and generate release notes.
+   - Creates a GitHub release and uploads the archive as a release asset.
+3. `.github/workflows/publish.yml` opens a pull request to the Bazel Central Registry via `publish-to-bcr`.
+4. `.github/workflows/package.yml` publishes all packages to PyPI.
+
+### Why a custom archive?
+
+The release uses a custom-built archive (`release_prep.sh`) instead of GitHub's
+auto-generated source archive (`/archive/refs/tags/`) for two reasons:
+
+- **`strip_prefix` mismatch**: GitHub names the folder `<repo>-<tag>` (e.g. `lobster-lobster-0.13.2/`),
+  but BCR's `source.template.json` expects `<repo>-<version>` (e.g. `lobster-0.13.2/`).
+- **Unstable SHA-256**: GitHub can regenerate auto archives at any time, changing the hash
+  and breaking BCR's integrity check for existing users. BCR explicitly rejects such URLs as unstable.
+
+### Required secret
+
+`BCR_PUBLISH_TOKEN`: A classic GitHub PAT with `workflow` and `repo` scopes, with write
+access to the BCR fork. The default fork is `bmw-software-engineering/bazel-central-registry`
+(overrideable via the `registry_fork` input in manual dispatch).


### PR DESCRIPTION
Add release/publish pipelines, BCR templates, and docs to generate and publish BCR PRs automatically.

Note: To open BCR PRs through a fork, add a repository secret named `BCR_PUBLISH_TOKEN` in the lobster repository.  
This secret must be a classic PAT (`repo` + `workflow`) from the GitHub account that owns (or can push to) the configured BCR fork, for example `bmw-software-engineering/bazel-central-registry`.