### PR TITLE
Add link to user manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * `trlc bazel dep`: update to trlc==2.0.5
 
+* Fixed wrong links in [README](README.md).
+
 ### 1.0.3
 
 * `lobster-html-report`:

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ Alternatively, use `pipx`:
 $ pipx install bmw-lobster --include-deps
 ```
 
-For the HTML Report `graphviz` is also used to generate the tracing policy diagram. More on that in the user [manual](https://github.com/bmw-software-engineering/lobster/blob/main/documentation/user-manual.md).
+For the HTML Report `graphviz` is also used to generate the tracing policy diagram.
+More on tracing policies can be found in the user manual on
+[configuration files](documentation/config_files.md).
 
 ```
 $ sudo apt-get install -y graphviz
 ```
 
-The `lobster-cpp` converter tool needs a specific version of `clang-tidy`. Please see [here](https://github.com/bmw-software-engineering/lobster/blob/main/documentation/user-manual.md#clang-tidy-file-generation) to create it.
+The `lobster-cpp` converter tool needs a specific version of `clang-tidy`.
+Please see [here](documentation/user-manual.md#clang-tidy-file-generation) to create it.
 
 ## Supported inputs
 
@@ -76,6 +79,7 @@ The following verification and miscellaneous frameworks are supported:
 
 ## Documentation
 
+* [User Manual](documentation/user-manual.md)
 * Writing [configuration files](documentation/config_files.md) for LOBSTER.
 * It is easy to expand the languages and activities supported by
   LOBSTER by adding new tracing tools, as long as they create data in
@@ -140,7 +144,8 @@ You can consider lobster as a set of
 3. the report creation tool and
 4. a renderer for the tracing report.
 
-For a more detailed description please read our [user guide](https://github.com/bmw-software-engineering/lobster/blob/main/documentation/config_files.md).
+For a more detailed description please read our user manual on
+[configuration files](documentation/config_files.md).
 
 These steps are in the following diagram and go from left to right side:
 

--- a/documentation/user-manual.md
+++ b/documentation/user-manual.md
@@ -1,4 +1,4 @@
-# LOBSTER User's Guide
+# LOBSTER User Manual
 
 ## Introduction and overview
 


### PR DESCRIPTION
The `README.md` file now contains a direct link to the user manual under the "Documentation" section. Earlier it contained only one link to specific section of the user manual regarding the clang-tidy file generation. If the user was not interested in that, the user would not find the user manual.

Also homogenized the naming of "User's Guide" and "User Manual" to only "User Manual". The file name was (and still is) `user-manual.md`, so sticking with "User Manual" everywhere else is sensible and is a smaller refactoring than renaming the file to "user-guide.md"

Also homogenized the way how references from `README.md` to other `.md` files are made: now using only relative references and no absolute references that include the repository URL. (Absolute references may cause problems in repository forks, as their references will always point to the BMW repository, not the fork.)
Note that `packages/lobster-core/setup.py` (and others) convert relative references to absolute references pointing to https://github.com/bmw-software-engineering/lobster, so the publication to pypi.org is not affected.