### PR TITLE
Replace trlc make target with bazel target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
 common --experimental_enable_bzlmod
+test --test_output=all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
+      - name: Setup bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
       - name: Run TRLC
         run: |
-          make trlc
+          bazel test //lobster:trlc
   test:
     name: TestSuite
     needs: [changes, lint-code, lint-system-tests, trlc]

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ lint-unit-tests: style
 		--reports=no \
 		tests_unit
 
-trlc:
-	trlc lobster --error-on-warnings --verify
-
 style:
 	@python3 -m pycodestyle lobster tests_system \
 		--exclude=assets.py,html_report_js.py

--- a/lobster/BUILD.bazel
+++ b/lobster/BUILD.bazel
@@ -1,2 +1,44 @@
 # BUILD.bazel
 # gazelle:exclude __init__.py
+
+load("@rules_python//python:defs.bzl", "py_test")
+load("//:requirements.bzl", "requirement")
+
+filegroup(
+	name = "trlc_inputs",
+	srcs = glob([
+		"*.rsl",
+		"*.trlc",
+	]) + [
+		"//lobster/tools/codebeamer:trlc_sources",
+		"//lobster/tools/core/ci_report:trlc_sources",
+		"//lobster/tools/core/html_report:trlc_sources",
+		"//lobster/tools/core/online_report:trlc_sources",
+		"//lobster/tools/core/report:trlc_sources",
+		"//lobster/tools/core/rst_report:trlc_sources",
+		"//lobster/tools/cpp:trlc_sources",
+		"//lobster/tools/cpptest:trlc_sources",
+		"//lobster/tools/gtest:trlc_sources",
+		"//lobster/tools/json:trlc_sources",
+		"//lobster/tools/pkg:trlc_sources",
+		"//lobster/tools/python:trlc_sources",
+		"//lobster/tools/trlc:trlc_sources",
+	],
+	visibility = ["//visibility:public"],
+)
+
+py_test(
+	name = "trlc",
+	srcs = ["trlc_runner.py"],
+	main = "trlc_runner.py",
+	args = [
+		"lobster",
+		"--error-on-warnings",
+		"--verify",
+	],
+	data = [
+		":trlc_inputs"
+	],
+	deps = [requirement("trlc")],
+	visibility = ["//visibility:public"],
+)

--- a/lobster/tools/codebeamer/BUILD.bazel
+++ b/lobster/tools/codebeamer/BUILD.bazel
@@ -4,6 +4,12 @@ load("//:requirements.bzl", "requirement")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "codebeamer",
     srcs = [

--- a/lobster/tools/core/ci_report/BUILD.bazel
+++ b/lobster/tools/core/ci_report/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "ci_report",
     srcs = ["ci_report.py"],

--- a/lobster/tools/core/html_report/BUILD.bazel
+++ b/lobster/tools/core/html_report/BUILD.bazel
@@ -4,6 +4,12 @@ load("//:requirements.bzl", "requirement")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "html_report",
     srcs = [

--- a/lobster/tools/core/online_report/BUILD.bazel
+++ b/lobster/tools/core/online_report/BUILD.bazel
@@ -4,6 +4,12 @@ load("//:requirements.bzl", "requirement")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "online_report",
     srcs = [

--- a/lobster/tools/core/report/BUILD.bazel
+++ b/lobster/tools/core/report/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "report",
     srcs = ["report.py"],

--- a/lobster/tools/core/rst_report/BUILD.bazel
+++ b/lobster/tools/core/rst_report/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "rst_report",
     srcs = [

--- a/lobster/tools/cpp/BUILD.bazel
+++ b/lobster/tools/cpp/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "cpp",
     srcs = [

--- a/lobster/tools/cpptest/BUILD.bazel
+++ b/lobster/tools/cpptest/BUILD.bazel
@@ -4,6 +4,12 @@ load("//:requirements.bzl", "requirement")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "cpptest",
     srcs = [

--- a/lobster/tools/gtest/BUILD.bazel
+++ b/lobster/tools/gtest/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "gtest",
     srcs = ["gtest.py"],

--- a/lobster/tools/json/BUILD.bazel
+++ b/lobster/tools/json/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "json",
     srcs = ["json.py"],

--- a/lobster/tools/pkg/BUILD.bazel
+++ b/lobster/tools/pkg/BUILD.bazel
@@ -3,6 +3,12 @@ load("@rules_python//python:defs.bzl", "py_library")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "pkg",
     srcs = [

--- a/lobster/tools/python/BUILD.bazel
+++ b/lobster/tools/python/BUILD.bazel
@@ -4,6 +4,12 @@ load("//:requirements.bzl", "requirement")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "python",
     srcs = ["python.py"],

--- a/lobster/tools/trlc/BUILD.bazel
+++ b/lobster/tools/trlc/BUILD.bazel
@@ -4,6 +4,12 @@ load("//:requirements.bzl", "requirement")
 # BUILD.bazel
 # gazelle:exclude __init__.py
 
+filegroup(
+    name = "trlc_sources",
+    srcs = glob(["**/*.trlc"]),
+    visibility = ["//visibility:public"],
+)
+
 py_library(
     name = "trlc",
     srcs = [

--- a/lobster/trlc_runner.py
+++ b/lobster/trlc_runner.py
@@ -1,0 +1,15 @@
+"""Entrypoint to run pip-installed TRLC as a Bazel py_test."""
+
+import runpy
+
+
+def main() -> None:
+    # Prefer package-as-script, then fall back to the historical module path.
+    try:
+        runpy.run_module("trlc", run_name="__main__")
+    except ImportError:
+        runpy.run_module("trlc.trlc", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Makefile: Removed the trlc target that used trlc lobster --error-on-warnings --verify
  - CI workflow (.github/workflows/ci.yml):
  - Replaced Python dependency installation with Bazel setup (bazel-contrib/setup-bazel)
  - Updated the trlc invocation to use bazel test instead of make
  - Enabled Bazel caching for improved performance
- Bazel BUILD files:
  - Updated lobster/BUILD.bazel with a new py_test rule for trlc that includes all necessary inputs and dependencies
  - Added trlc_sources filegroups to 11 tool modules to expose TRLC configuration files needed by the bazel test
- .bazelrc: Added test configuration flag to control test outpu