### PR TITLE
replace integration tests make targets with bazel targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ export LOBSTER_ROOT=$(PWD)
 export PYTHONPATH=$(LOBSTER_ROOT)
 export PATH:=$(LOBSTER_ROOT):$(PATH)
 
+BAZEL_BIN := $(shell command -v bazelisk 2>/dev/null || command -v bazel-8.5.1 2>/dev/null || command -v bazel 2>/dev/null)
+
 TOOL_FOLDERS := $(shell \
 	(find ./lobster/tools -mindepth 1 -maxdepth 1 -type d \
 		| grep -v -E '__pycache__|parser|core$$' \
@@ -101,10 +103,15 @@ clang-tidy:
 
 integration-tests: packages
 	(cd tests_integration/projects/basic; make)
-	(cd tests_integration/projects/coverage; make)
-	(cd tests_integration/projects/coverage_half; make)
-	(cd tests_integration/projects/coverage_mix; make)
-	(cd tests_integration/projects/coverage_zero; make)
+	$(BAZEL_BIN) test \
+		//tests_integration/projects/coverage:traceability \
+		//tests_integration/projects/coverage_half:traceability \
+		//tests_integration/projects/coverage_mix:traceability \
+		//tests_integration/projects/coverage_zero:traceability \
+		--keep_going \
+		--test_output=all \
+		--verbose_failures \
+		--verbose_test_summary
 	(cd tests_integration/projects/cpp_focus; make)
 
 codebeamer-pem:

--- a/bazel/private/lobster_trlc.bzl
+++ b/bazel/private/lobster_trlc.bzl
@@ -4,21 +4,43 @@ load("//bazel:providers.bzl", "LobsterProvider")
 def _lobster_trlc_subrule_impl(ctx, requirements, config, _lobster_trlc):
     lobster_trlc_trace = ctx.actions.declare_file(ctx.label.name + ".lobster")
 
-    args = ctx.actions.args()
-    args.add_all(["--config", config.path])
-    args.add_all(["--out", lobster_trlc_trace.path])
+    package_dir = ctx.label.package
+    config_base = config.basename
+    command = """
+set -euo pipefail
+exec_root="$PWD"
+tool_path="{tool}"
+case "$tool_path" in
+    /*) ;;
+    *) tool_path="$exec_root/$tool_path" ;;
+esac
+out_path="{out}"
+case "$out_path" in
+    /*) ;;
+    *) out_path="$exec_root/$out_path" ;;
+esac
+cd {package_dir}
+"$tool_path" --config {config_base} --out "$out_path"
+""".format(
+        package_dir = package_dir,
+        tool = _lobster_trlc.executable.path,
+        config_base = config_base,
+        out = lobster_trlc_trace.path,
+    )
 
-    ctx.actions.run(
-        executable = _lobster_trlc,
+    ctx.actions.run_shell(
+        command = command,
         inputs = requirements + [config],
         outputs = [lobster_trlc_trace],
-        arguments = [args],
+        tools = [_lobster_trlc],
         progress_message = "lobster-trlc {}".format(lobster_trlc_trace.path),
     )
 
     return [
         lobster_trlc_trace,
-        LobsterProvider(lobster_input = {lobster_trlc_trace.basename: lobster_trlc_trace.path}),
+        # Keep config substitutions one-to-one with Make behavior by preserving
+        # plain basenames in lobster.conf source fields.
+        LobsterProvider(lobster_input = {lobster_trlc_trace.basename: lobster_trlc_trace.basename}),
     ]
 
 subrule_lobster_trlc = subrule(

--- a/tests_integration/projects/BUILD.bazel
+++ b/tests_integration/projects/BUILD.bazel
@@ -1,0 +1,1 @@
+# Package marker for shared integration test Starlark helpers.

--- a/tests_integration/projects/coverage/BUILD.bazel
+++ b/tests_integration/projects/coverage/BUILD.bazel
@@ -1,0 +1,39 @@
+load("//:lobster.bzl", "lobster_trlc")
+load("//tests_integration/projects:report_reference_test.bzl", "lobster_reference_test")
+load("@trlc//:trlc.bzl", "trlc_requirements", "trlc_specification")
+
+trlc_specification(
+    name = "req_spec",
+    srcs = ["example.rsl"],
+)
+
+trlc_requirements(
+    name = "reqs",
+    srcs = [
+        "softreq_example.trlc",
+        "sysreq_example.trlc",
+    ],
+    spec = [":req_spec"],
+)
+
+lobster_trlc(
+    name = "softreq",
+    config = "soft_req_trlc_config.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_trlc(
+    name = "sysreq",
+    config = "sys_req_trlc_config.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_reference_test(
+    name = "traceability",
+    config = "lobster.conf",
+    inputs = [
+        ":softreq",
+        ":sysreq",
+    ],
+    reference = "report.reference_output",
+)

--- a/tests_integration/projects/coverage_half/BUILD.bazel
+++ b/tests_integration/projects/coverage_half/BUILD.bazel
@@ -1,0 +1,39 @@
+load("//:lobster.bzl", "lobster_trlc")
+load("//tests_integration/projects:report_reference_test.bzl", "lobster_reference_test")
+load("@trlc//:trlc.bzl", "trlc_requirements", "trlc_specification")
+
+trlc_specification(
+    name = "req_spec",
+    srcs = ["example.rsl"],
+)
+
+trlc_requirements(
+    name = "reqs",
+    srcs = [
+        "softreq_example.trlc",
+        "sysreq_example.trlc",
+    ],
+    spec = [":req_spec"],
+)
+
+lobster_trlc(
+    name = "softreq",
+    config = "soft_req_trlc_config.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_trlc(
+    name = "sysreq",
+    config = "sys_req_trlc_config.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_reference_test(
+    name = "traceability",
+    config = "lobster.conf",
+    inputs = [
+        ":softreq",
+        ":sysreq",
+    ],
+    reference = "report.reference_output",
+)

--- a/tests_integration/projects/coverage_mix/BUILD.bazel
+++ b/tests_integration/projects/coverage_mix/BUILD.bazel
@@ -1,0 +1,47 @@
+load("//:lobster.bzl", "lobster_trlc")
+load("//tests_integration/projects:report_reference_test.bzl", "lobster_reference_test")
+load("@trlc//:trlc.bzl", "trlc_requirements", "trlc_specification")
+
+trlc_specification(
+    name = "req_spec",
+    srcs = ["example.rsl"],
+)
+
+trlc_requirements(
+    name = "reqs",
+    srcs = [
+        "req_a.trlc",
+        "req_b.trlc",
+        "test_spec.trlc",
+    ],
+    spec = [":req_spec"],
+)
+
+lobster_trlc(
+    name = "req_a",
+    config = "trlc_req_a.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_trlc(
+    name = "req_b",
+    config = "trlc_req_b.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_trlc(
+    name = "test_a",
+    config = "trlc_test_spec.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_reference_test(
+    name = "traceability",
+    config = "lobster.conf",
+    inputs = [
+        ":req_a",
+        ":req_b",
+        ":test_a",
+    ],
+    reference = "report.reference_output",
+)

--- a/tests_integration/projects/coverage_zero/BUILD.bazel
+++ b/tests_integration/projects/coverage_zero/BUILD.bazel
@@ -1,0 +1,39 @@
+load("//:lobster.bzl", "lobster_trlc")
+load("//tests_integration/projects:report_reference_test.bzl", "lobster_reference_test")
+load("@trlc//:trlc.bzl", "trlc_requirements", "trlc_specification")
+
+trlc_specification(
+    name = "req_spec",
+    srcs = ["example.rsl"],
+)
+
+trlc_requirements(
+    name = "reqs",
+    srcs = [
+        "softreq_example.trlc",
+        "sysreq_example.trlc",
+    ],
+    spec = [":req_spec"],
+)
+
+lobster_trlc(
+    name = "softreq",
+    config = "soft_req_trlc_config.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_trlc(
+    name = "sysreq",
+    config = "sys_req_trlc_config.yaml",
+    requirements = [":reqs"],
+)
+
+lobster_reference_test(
+    name = "traceability",
+    config = "lobster.conf",
+    inputs = [
+        ":softreq",
+        ":sysreq",
+    ],
+    reference = "report.reference_output",
+)

--- a/tests_integration/projects/report_reference_test.bzl
+++ b/tests_integration/projects/report_reference_test.bzl
@@ -1,0 +1,120 @@
+load("//:lobster.bzl", "LobsterProvider")
+
+def _lobster_reference_test_impl(ctx):
+    lobster_config_substitutions = {}
+    for input_target in ctx.attr.inputs:
+        lobster_config_substitutions.update(input_target[LobsterProvider].lobster_input)
+
+    lobster_config = ctx.actions.declare_file("{}_expanded_lobster.conf".format(ctx.attr.name))
+    ctx.actions.expand_template(
+        template = ctx.file.config,
+        output = lobster_config,
+        substitutions = lobster_config_substitutions,
+    )
+
+    lobster_report = ctx.actions.declare_file("{}_report.json".format(ctx.attr.name))
+
+    report_command = """
+set -euo pipefail
+
+exec_root="$PWD"
+tool_path="{tool}"
+case "$tool_path" in
+  /*) ;;
+  *) tool_path="$exec_root/$tool_path" ;;
+esac
+
+config_rel="$1"
+out_rel="$2"
+shift 2
+
+stage_dir="$(mktemp -d)"
+trap 'rm -rf "$stage_dir"' EXIT
+
+cp "$config_rel" "$stage_dir/lobster.conf"
+
+while [ "$#" -gt 0 ]; do
+  src_rel="$1"
+  src_base="$2"
+  shift 2
+    src_path="$src_rel"
+    case "$src_path" in
+        /*) ;;
+        *) src_path="$exec_root/$src_path" ;;
+    esac
+    if [ ! -f "$src_path" ]; then
+        echo "missing staged input: $src_base from $src_path" >&2
+        exit 1
+    fi
+    cp "$src_path" "$stage_dir/$src_base"
+done
+
+cd "$stage_dir"
+"$tool_path" --lobster-config lobster.conf --out "$exec_root/$out_rel"
+""".format(
+        tool = ctx.executable._lobster_report.path,
+    )
+
+    report_args = ctx.actions.args()
+    report_args.add(lobster_config.path)
+    report_args.add(lobster_report.path)
+    for input_file in ctx.files.inputs:
+        report_args.add(input_file.path)
+        report_args.add(input_file.basename)
+
+    ctx.actions.run_shell(
+        command = report_command,
+        inputs = ctx.files.inputs + [lobster_config],
+        outputs = [lobster_report],
+        arguments = [report_args],
+        tools = [ctx.executable._lobster_report],
+        progress_message = "lobster-report {}".format(lobster_report.path),
+    )
+
+    test_executable = ctx.actions.declare_file("{}_reference_test.sh".format(ctx.attr.name))
+    script = """#!/usr/bin/env bash
+set -euo pipefail
+
+report="${{TEST_SRCDIR}}/${{TEST_WORKSPACE}}/{report}"
+reference="${{TEST_SRCDIR}}/${{TEST_WORKSPACE}}/{reference}"
+
+diff -u "$report" "$reference"
+""".format(
+        report = lobster_report.short_path,
+        reference = ctx.file.reference.short_path,
+    )
+    ctx.actions.write(
+        output = test_executable,
+        content = script,
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = test_executable,
+        files = depset([lobster_report]),
+        runfiles = ctx.runfiles(files = [lobster_report, ctx.file.reference]),
+    )]
+
+lobster_reference_test = rule(
+    implementation = _lobster_reference_test_impl,
+    attrs = {
+        "config": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "inputs": attr.label_list(
+            providers = [LobsterProvider],
+            mandatory = True,
+        ),
+        "reference": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "_lobster_report": attr.label(
+            default = "//:lobster-report",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    test = True,
+)


### PR DESCRIPTION
Converted Make targets to Bazel: Replaced Make-based integration tests with four Bazel targets for coverage traceability tests (coverage, coverage_half, coverage_mix, coverage_zero), improving build system integration and test reproducibility.