### PR TITLE
ci(bcr): fix BCR publish attestations and sync presubmit template

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -10,9 +10,8 @@ incompatible_flags:
 
 matrix:
   platform:
-    - ubuntu2204
+    - ubuntu2404
     - macos
-    - windows
   bazel:
     - 8.x
   python_version:
@@ -28,12 +27,66 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_flags:
-      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # ← explicit Python version
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
     build_targets:
       - "@lobster//:lobster"
     test_flags:
-      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # ← explicit Python version
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
     test_targets:
       - "@lobster//tests_unit/..."
       - "@lobster//tests_system/..."
       - "@lobster//tests_integration/..."
+      # cpp_focus:fruit_test is an intentionally-failing gtest fixture used only to
+      # generate LOBSTER tracing metadata (upstream runs it with "|| true"). Its
+      # BasketTest.ClearBasket case asserts an empty basket while the clearing code
+      # is commented out, so it must be excluded from the presubmit test run.
+      - "-@lobster//tests_integration/projects/cpp_focus:fruit_test"
+      # projects/basic:traceability renders an HTML report with lobster-html-report,
+      # which requires the Graphviz "dot" binary. Graphviz is not part of the BCR CI
+      # images, so this test fails with "please install Graphviz".
+      - "-@lobster//tests_integration/projects/basic:traceability"
+      # projects/sphinx_rst_report:test_sphinx_build runs a full Sphinx build with
+      # warnings-as-errors; the rst_report tool / sphinx.ext.graphviz also need the
+      # Graphviz "dot" binary, which is likewise absent from the BCR CI images.
+      - "-@lobster//tests_integration/projects/sphinx_rst_report:test_sphinx_build"
+      # The lobster_codebeamer system tests stand up a Flask HTTPS mock server on
+      # localhost; they depend on lobster's own provisioned CI environment and do not
+      # run reliably in the sandboxed BCR test environment.
+      - "-@lobster//tests_system/lobster_codebeamer/..."
+
+  # Windows needs its own task because lobster's shared requirements_lock.txt is not
+  # universal, so the lobster_pip_hub_dependencies hub is missing Windows-only marker
+  # dependencies. Two of them break analysis (which aborts the whole build) on Windows:
+  #   * Sphinx requires `colorama`  -> breaks tests_unit/sphinx_extension
+  #   * Selenium (via trio) needs `cffi` -> breaks tests_system/lobster_html_report
+  # Both target trees are therefore additionally excluded on Windows only.
+  run_test_module_windows:
+    name: "Verify lobster on Windows (Python ${{ python_version }})"
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
+    build_targets:
+      - "@lobster//:lobster"
+    test_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
+    test_targets:
+      - "@lobster//tests_unit/..."
+      - "@lobster//tests_system/..."
+      - "@lobster//tests_integration/..."
+      # Keep the exclusions in sync with the run_test_module task above.
+      - "-@lobster//tests_integration/projects/cpp_focus:fruit_test"
+      - "-@lobster//tests_integration/projects/basic:traceability"
+      - "-@lobster//tests_integration/projects/sphinx_rst_report:test_sphinx_build"
+      - "-@lobster//tests_system/lobster_codebeamer/..."
+      # Windows-only: the shared pip hub has no `colorama`, which Sphinx requires on
+      # Windows, so the Sphinx extension tests cannot be analyzed here.
+      - "-@lobster//tests_unit/sphinx_extension/..."
+      # Windows-only: the shared pip hub has no `cffi`, which Selenium (via trio)
+      # requires on Windows, so the html-report tests cannot be analyzed here.
+      - "-@lobster//tests_system/lobster_html_report/..."
+      # Windows-only: the online-report tool converts filesystem paths to GitHub URLs,
+      # and these tests compare against golden files/strings that assume POSIX path
+      # separators ("/") and LF line endings, so they fail on Windows only.
+      - "-@lobster//tests_unit/lobster_online_report/..."
+      - "-@lobster//tests_system/lobster_online_report/..."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,13 +30,14 @@ env:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
     with:
       tag_name: ${{ inputs.tag_name }}
       registry_fork: ${{ inputs.registry_fork }}
       draft: false
       attest: true
       tag_prefix: "lobster-"
+      download_default_release_artifacts: true
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Update the Publish-to-BCR workflow and BCR presubmit template so future
releases produce a valid, passing BCR entry.

publish.yml:
- Bump bazel-contrib/publish-to-bcr v1.2.0 -> v1.4.1 for the fixed
  attestation-upload path (attaching *.intoto.jsonl to the release and
  immutable-release handling).
- Set download_default_release_artifacts: true so publish pulls the
  archive and attestations from the release_ruleset run and computes
  integrity locally.

.bcr/presubmit.yml:
- Sync the template with the maintained BCR entry: drop windows from the
  main matrix, add a dedicated run_test_module_windows task, and exclude
  environment-dependent tests (Graphviz-based basic:traceability and
  sphinx_rst_report, cpp_focus:fruit_test, lobster_codebeamer, and the
  Windows-only sphinx/html-report/online-report trees).