### PR TITLE
bazel: add Bazel equivalent of make codebeamer-pem

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-common --experimental_enable_bzlmod
+common --enable_bzlmod
 test --test_output=all

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ integration-tests: packages
 	(cd tests_integration/projects/coverage_zero; make)
 	(cd tests_integration/projects/cpp_focus; make)
 
+# Bazel equivalent: bazel build //tests_system/lobster_codebeamer/data:codebeamer_pem
 codebeamer-pem:
 	@echo "🔐 Generating cert.pem and key.pem for codebeamer system tests..."
 	@mkdir -p tests_system/lobster_codebeamer/data/ssl

--- a/documentation/manual-lobster_codebeamer.md
+++ b/documentation/manual-lobster_codebeamer.md
@@ -74,14 +74,16 @@ Notes:
 
 ## Generating SSL Certificates
 
-To test with HTTPS using a mock server, you will need to generate a self-signed certificate (`cert.pem`) and private key (`key.pem`).
+To test with HTTPS using a mock server, you will need to generate a self-signed
+certificate (`cert.pem`) and private key (`key.pem`).
 
 You can generate them using OpenSSL with the following command:
 
 ```bash
 openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365
 ```
-When prompted, you can enter values or simply press Enter to skip. This will create:
+When prompted, you can enter values or simply press Enter to skip. This will
+create:
 
 - cert.pem – the self-signed certificate
 - key.pem – the private key
@@ -97,6 +99,22 @@ tests_system/lobster_codebeamer/data/ssl/cert.pem
 tests_system/lobster_codebeamer/data/ssl/key.pem
 
 These are used by the Flask-based mock server during testing.
+
+### Bazel (recommended)
+
+If you are using Bazel, build the `codebeamer_pem` target to generate fresh
+self-signed certificate and private key files at build time:
+
+```bash
+bazel build //tests_system/lobster_codebeamer/data:codebeamer_pem
+```
+
+The generated files are exposed to tests as Bazel runfiles:
+
+- `tests_system/lobster_codebeamer/data/cert.pem` – the self-signed certificate
+- `tests_system/lobster_codebeamer/data/key.pem` – the private key
+
+The legacy Make flow still uses `tests_system/lobster_codebeamer/data/ssl/` until it is retired.
 
 ## Use-cases
 

--- a/tests_system/README.md
+++ b/tests_system/README.md
@@ -100,7 +100,7 @@ These settings copy the arguments from the `Makefile`.
 The argument `-t .` is needed to help `unittest` to resolve import statements.
 The argument `-s system-test` tells `unittest` to start discovery in this directory.
 
-Make sure to instruct VSCode to use the Pyton interpreter from your virtual environment,
+Make sure to instruct VSCode to use the Python interpreter from your virtual environment,
 and install `requirements_dev.txt`:
 ```
 > pip install -r requirements_dev.txt

--- a/tests_system/lobster_codebeamer/data/BUILD.bazel
+++ b/tests_system/lobster_codebeamer/data/BUILD.bazel
@@ -1,11 +1,22 @@
 load("@rules_python//python:defs.bzl", "py_library")
 
+# Bazel equivalent of: make codebeamer-pem
+genrule(
+    name = "codebeamer_pem",
+    outs = [
+        "cert.pem",
+        "key.pem",
+    ],
+    cmd = "openssl req -x509 -newkey rsa:2048 -nodes " +
+          "-keyout $(RULEDIR)/key.pem " +
+          "-out $(RULEDIR)/cert.pem " +
+          "-days 3650 " +
+          "-subj '/CN=localhost' > /dev/null 2>&1",
+)
+
 filegroup(
     name = "codebeamer_data_system",
-    srcs = glob([
-        "ssl/*.pem",
-        "*.lobster",
-    ]),
+    srcs = glob(["*.lobster"]) + [":codebeamer_pem"],
     visibility = ["//visibility:public"],
 )
 

--- a/tests_system/lobster_codebeamer/mock_server.py
+++ b/tests_system/lobster_codebeamer/mock_server.py
@@ -1,5 +1,6 @@
 import json
 import socket
+from pathlib import Path
 from time import sleep
 from typing import List
 from flask import Flask, Response, request
@@ -12,9 +13,18 @@ import requests
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
 
-# Config
-CERT_PATH = 'tests_system/lobster_codebeamer/data/ssl/cert.pem'
-KEY_PATH = 'tests_system/lobster_codebeamer/data/ssl/key.pem'
+# SSL cert/key lookup differs by test runner:
+# - Bazel runfiles expose cert.pem/key.pem directly under data/
+# - Make writes cert.pem/key.pem under data/ssl/ via make codebeamer-pem
+# TODO: Remove the Make fallback after make system-tests is retired.
+_DATA_DIR = Path(__file__).parent / "data"
+_BAZEL_CERT = _DATA_DIR / "cert.pem"
+_BAZEL_KEY = _DATA_DIR / "key.pem"
+_MAKE_CERT = _DATA_DIR / "ssl" / "cert.pem"
+_MAKE_KEY = _DATA_DIR / "ssl" / "key.pem"
+_USE_BAZEL_LAYOUT = _BAZEL_CERT.exists()
+CERT_PATH = str(_BAZEL_CERT if _USE_BAZEL_LAYOUT else _MAKE_CERT)
+KEY_PATH = str(_BAZEL_KEY if _USE_BAZEL_LAYOUT else _MAKE_KEY)
 MOCK_ROUTE_QUERY_ID = '/api/v3/reports/<int:report_id>/items'
 MOCK_ROUTE_QUERY_STRING = '/api/v3/items/query'
 ARE_YOU_RUNNING_ROUTE = '/are-you-running'


### PR DESCRIPTION
Bazel equivalent of `make codebeamer-pem`. Adds a `genrule` that runs OpenSSL at build time and exposes the generated SSL certificate files as Bazel outputs for the codebeamer mock server.

## Files changed
- BUILD.bazel — `codebeamer_pem` target
- mock_server.py — cert path resolution for Bazel runfiles
- manual-lobster_codebeamer.md — document Make and Bazel cert paths
- .bazelrc — replace deprecated `--experimental_enable_bzlmod` with `--enable_bzlmod`

## How to test
```bash
bazel build //tests_system/lobster_codebeamer/data:codebeamer_pem
bazel test //tests_system/lobster_codebeamer:test_lobster_codebeamer
```

## Note
mock_server.py keeps temporary dual-path support during the migration:
- Bazel: `data/cert.pem` and `data/key.pem`
- Make: `data/ssl/cert.pem` and `data/ssl/key.pem`

The Make fallback can be removed once the remaining system tests are fully Bazel-only.