### PR TITLE
Support custom Codebeamer item text through API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ### 1.0.7-dev
 
+* `lobster-codebeamer`:
+  Added the API-only `item_to_text` parameter to the configuration object of the
+  `lobster_codebeamer` API for populating the LOBSTER item's text property.
+  For example, the API user may provide a function that returns a `String` for the
+  LOBSTER item based on the Codebeamer item's data.
+
 * Removed wrong statement from `schemas.md` regarding "status" field.
 
 ### 1.0.6

--- a/lobster/tools/codebeamer/codebeamer.py
+++ b/lobster/tools/codebeamer/codebeamer.py
@@ -343,7 +343,11 @@ def to_lobster(cb_config: Config, cb_item: dict):
         cb_config.cb_auth_conf.root, item_name, kind)
     item = _create_lobster_item(
         schema_config["class"],
-        common_params, item_name, status)
+        common_params, item_name, status,
+        cb_config.item_to_text(cb_item)
+        if cb_config.item_to_text is not None and
+        schema_config["class"] in (Requirement, Activity)
+        else None)
 
     if cb_config.references:
         for displayed_name in cb_config.references:
@@ -394,7 +398,8 @@ def _create_common_params(namespace: str, cb_item: dict, cb_root: str,
     }
 
 
-def _create_lobster_item(schema_class, common_params, item_name, status):
+def _create_lobster_item(schema_class, common_params, item_name, status,
+                         text: Optional[str]):
     """
     Creates and returns a Lobster item based on the schema class.
     Args:
@@ -402,6 +407,8 @@ def _create_lobster_item(schema_class, common_params, item_name, status):
     common_params (dict): Common parameters for the item.
     item_name (str): Name of the item.
     status (str): Status of the item.
+    text (str): Optional text generated from the Codebeamer item.
+      Is ignored for Implementation schema.
     Returns:
     Object: An instance of the schema class with the appropriate parameters.
     """
@@ -409,7 +416,7 @@ def _create_lobster_item(schema_class, common_params, item_name, status):
         return Requirement(
             **common_params,
             framework="codebeamer",
-            text=None,
+            text=text,
             status=status,
             name= item_name
         )
@@ -425,6 +432,7 @@ def _create_lobster_item(schema_class, common_params, item_name, status):
         return Activity(
             **common_params,
             framework="codebeamer",
+            text=text,
             status=status
         )
 

--- a/lobster/tools/codebeamer/config.py
+++ b/lobster/tools/codebeamer/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List, Union
+from typing import Callable, Optional, List, Union
 
 
 @dataclass
@@ -24,6 +24,7 @@ class Config:
     timeout: int
     out: str
     cb_auth_conf: AuthenticationConfig
+    item_to_text: Optional[Callable[[dict], Optional[str]]] = None
 
     @property
     def base(self) -> str:

--- a/lobster/tools/codebeamer/requirements/text_delegate_requirements.trlc
+++ b/lobster/tools/codebeamer/requirements/text_delegate_requirements.trlc
@@ -1,0 +1,26 @@
+package codebeamer_req
+import req
+
+req.Software_Requirement Item_To_Text_Delegate {
+  description = '''
+    The "to_lobster" function shall call the optional "item_to_text" delegate
+    with each raw Codebeamer item and shall assign its returned string to the
+    text field for Requirement and Activity items.
+
+    Note: This implies the delegate is not called for Implementation items.
+  '''
+}
+
+req.Software_Requirement Item_To_Text_Delegate_Error_Propagation {
+  description = '''
+    The "lobster_codebeamer" function shall propagate an exception raised by
+    the "item_to_text" delegate without catching it.
+  '''
+}
+
+req.Software_Requirement Get_Query_Passes_Config_To_To_Lobster {
+  description = '''
+    The "get_query" function shall pass its "Config" object unchanged to
+    each invocation of the "to_lobster" function.
+  '''
+}

--- a/manual/tools/codebeamer.rst
+++ b/manual/tools/codebeamer.rst
@@ -53,6 +53,7 @@ Config
          num_request_retry=5,
          retry_error_codes=[500, 502, 503, 504],
          cb_auth_conf=auth,
+         item_to_text=None,
    )
 
 - ``references`` (List[str]): Names of Codebeamer fields whose referenced items should be traced (converted to ``req`` tags).
@@ -68,14 +69,31 @@ Config
 - ``retry_error_codes`` (List[int]): HTTP status codes that trigger retry logic (e.g. [500, 502, 503, 504]).
 - ``cb_auth_conf`` (AuthenticationConfig): Authentication + root endpoint.
 
+.. _codebeamer-item-to-text:
+
+- ``item_to_text`` (Callable[[dict], str | None] | None): Optional
+   delegate called once for each raw Codebeamer item. Its return value is
+   stored in the LOBSTER ``text`` field for requirements and activities;
+   returning ``None`` leaves the field empty. Exceptions propagate and abort
+   the ``lobster_codebeamer`` run.
+   Note that this is a pure API feature and cannot be configured through YAML.
+
 Stable API Function
 -------------------
 
 ``lobster_codebeamer(config: Config, out_file: str) -> None``
   Loads items (via query or tagged import) and writes them to a LOBSTER interchange file.
 
-Example (Using Query with Custom Settings)
--------------------------------------------
+Example (Using the ``Config.item_to_text`` API Interface)
+--------------------------------------------------
+
+This example shows how to use the ``item_to_text`` interface to combine a
+standard Codebeamer field and a custom field in the LOBSTER item's ``text``
+property.
+It assumes you have a Codebeamer instance with a custom field named
+"Upstream Requirements" that contains references to other items.
+The example extracts the "name" of each referenced item and appends them to the
+description of the item.
 
 ::
 
@@ -86,18 +104,30 @@ Example (Using Query with Custom Settings)
       root="https://codebeamer.example.com"
    )
 
+   def custom_item_to_text(item):
+      derived_from_field = next(
+         (field for field in item.get("customFields", [])
+          if field.get("name") == "Upstream Requirements"),
+         {},
+      )
+      derived_from = ", ".join(
+         value["name"] for value in derived_from_field.get("values", [])
+      )
+      return f"{item.get('description', '')}\nDerived from: {derived_from}"
+
    conf = Config(
       references=["Depends On", "Related To"],
       import_tagged=None,
       import_query=5678,
       verify_ssl=True,
       page_size=200,
-      schema="implementation",
+      schema="requirement",
       timeout=60,
       out=None,
       num_request_retry=3,
       retry_error_codes=[500, 502, 503, 504],
       cb_auth_conf=auth,
+      item_to_text=custom_item_to_text,
    )
 
    lobster_codebeamer(conf, "codebeamer_items.lobster")

--- a/packages/lobster-tool-codebeamer/README.md
+++ b/packages/lobster-tool-codebeamer/README.md
@@ -120,10 +120,11 @@ There are two ways you can use this tool:
 
        This command will extract activity traces (lobster-act-trace) with specified references.
 
-## Limitations
+## Getting more Item Data
 
-The key limitation is item text, which is currently not
-imported. However, we do plan to also import item text eventually.
+The Python API offers a way to populate the LOBSTER `text` property from
+arbitrary Codebeamer fields. See the [Codebeamer API documentation](https://bmw-software-engineering.github.io/lobster/api_documentation/manual/tools/codebeamer.html#codebeamer-item-to-text)
+for details about the `item_to_text` delegate and an example.
 
 ## Copyright & License information
 

--- a/tests_unit/lobster_codebeamer/BUILD.bazel
+++ b/tests_unit/lobster_codebeamer/BUILD.bazel
@@ -20,6 +20,12 @@ py_test(
 )
 
 py_test(
+    name = "test_text_delegate",
+    srcs = ["test_text_delegate.py"],
+    deps = ["//lobster/tools/codebeamer"],
+)
+
+py_test(
     name = "test_codebeamer_schema",
     srcs = ["test_codebeamer_schema.py"],
     data = ["test.netrc"],

--- a/tests_unit/lobster_codebeamer/test_text_delegate.py
+++ b/tests_unit/lobster_codebeamer/test_text_delegate.py
@@ -1,0 +1,137 @@
+import unittest
+from unittest.mock import patch
+
+from lobster.common.items import Implementation
+from lobster.tools.codebeamer.codebeamer import get_query, to_lobster
+from lobster.tools.codebeamer.config import AuthenticationConfig, Config
+
+
+class TextDelegateTest(unittest.TestCase):
+
+    @staticmethod
+    def _create_config(schema):
+        return Config(
+            num_request_retry=42,
+            retry_error_codes=[],
+            references=None,
+            import_tagged=None,
+            import_query=None,
+            baseline_id=None,
+            verify_ssl=None,
+            page_size=444,
+            schema=schema,
+            timeout=111,
+            out=None,
+            cb_auth_conf=AuthenticationConfig(
+                token=None,
+                user=None,
+                password=None,
+                root="http://the.requirements.server",
+            )
+        )
+
+    def setUp(self):
+        self._supported_schemas = ("Requirement", "Activity")
+        self._description_key = "description"
+        self._codebeamer_item = {
+            "id": 123,
+            "version": 456,
+            "tracker": {
+                "id": 789,
+            },
+            self._description_key:
+                "I told my code it had a bug, "
+                "but it just refused to take the feedback.",
+        }
+
+    def test_to_lobster_without_item_to_text(self):
+        # lobster-trace: codebeamer_text_req.Item_To_Text_Delegate
+        for schema in self._supported_schemas:
+            with self.subTest(schema=schema):
+                item = to_lobster(self._create_config(schema), self._codebeamer_item)
+
+                self.assertIsNone(item.text)
+
+    def test_to_lobster_item_to_text_returns_string(self):
+        # lobster-trace: codebeamer_text_req.Item_To_Text_Delegate
+        return_message = "So nice here!"
+        for schema in self._supported_schemas:
+            with self.subTest(schema=schema):
+                config = self._create_config(schema)
+                config.item_to_text = lambda item: return_message
+
+                item = to_lobster(config, self._codebeamer_item)
+
+                self.assertEqual(item.text, return_message)
+
+    def test_to_lobster_item_to_text_returns_none(self):
+        # lobster-trace: codebeamer_text_req.Item_To_Text_Delegate
+        for schema in self._supported_schemas:
+            with self.subTest(schema=schema):
+                config = self._create_config(schema)
+                config.item_to_text = lambda item: None
+
+                item = to_lobster(config, self._codebeamer_item)
+
+                self.assertIsNone(item.text)
+
+    def test_to_lobster_item_to_text_exception_propagates(self):
+        # lobster-trace: codebeamer_text_req.Item_To_Text_Delegate
+        # lobster-trace: codebeamer_text_req.Item_To_Text_Delegate_Error_Propagation
+        class DummyException(Exception):
+            pass
+
+        def item_to_text(_):
+            raise DummyException()
+
+        for schema in self._supported_schemas:
+            with self.subTest(schema=schema):
+                config = self._create_config(schema)
+                config.item_to_text = item_to_text
+
+                with self.assertRaises(DummyException):
+                    to_lobster(config, self._codebeamer_item)
+
+    @patch('lobster.tools.codebeamer.codebeamer.query_cb_single')
+    def test_get_query_passes_item_to_text_delegate(self, mock_query_cb_single):
+        # lobster-trace: codebeamer_text_req.Get_Query_Passes_Config_To_To_Lobster
+        for schema in self._supported_schemas:
+            with self.subTest(schema=schema):
+
+                # GIVEN a Config object with an item_to_text delegate that returns the
+                # description of the Codebeamer item
+                # and a responsive Codebeamer server
+                mock_query_cb_single.return_value = {
+                    "page": 1,
+                    "pageSize": 757575,
+                    "total": 1,
+                    "items": [self._codebeamer_item],
+                }
+                config = self._create_config(schema)
+                config.item_to_text = lambda item: item[self._description_key]
+
+                # WHEN get_query is called with the config object
+                result = get_query(config, "This is the query string.")
+
+                # THEN the item_to_text delegate is called and its return value is
+                # assigned to the text field of the resulting LOBSTER item
+                self.assertEqual(
+                    result[0].text,
+                    self._codebeamer_item[self._description_key],
+                )
+
+    def test_to_lobster_does_not_call_item_to_text_for_implementation(self):
+        # lobster-trace: codebeamer_text_req.Item_To_Text_Delegate
+        config = self._create_config("Implementation")
+
+        def item_to_text(_):
+            self.fail("item_to_text must not be called for Implementation")
+
+        config.item_to_text = item_to_text
+
+        item = to_lobster(config, self._codebeamer_item)
+
+        self.assertIsInstance(item, Implementation)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allow API users to provide an `item_to_text` delegate function that converts raw Codebeamer items into text for LOBSTER requirements and activities. The text is preserved through `lobster-report` and available to HTML reports.

Implementation:
Add the delegate to `Config`, document its API-only contract, and cover the behavior with unit tests.