### PR TITLE
Bump version to 1.0.7-dev after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Changelog
 
 
+### 1.0.7-dev
+
+
+
 ### 1.0.6
 
 * Call Lobster Report via bazel directly instead of using a symlink

--- a/lobster/common/version.py
+++ b/lobster/common/version.py
@@ -17,8 +17,8 @@
 # License along with this program. If not, see
 # <https://www.gnu.org/licenses/>.
 
-VERSION_TUPLE = (1, 0, 6)
-VERSION_SUFFIX = ""
+VERSION_TUPLE = (1, 0, 7)
+VERSION_SUFFIX = "dev"
 
 LOBSTER_VERSION = ".".join(str(x) for x in VERSION_TUPLE) + (
     f"-{VERSION_SUFFIX}" if VERSION_SUFFIX else ""

--- a/util/bump_version_post_release.py
+++ b/util/bump_version_post_release.py
@@ -18,10 +18,17 @@
 # <https://www.gnu.org/licenses/>.
 
 import os
+import subprocess
 
 import util.changelog
 
 from lobster.common.version import VERSION_TUPLE
+
+# Under `bazel run`, use the real workspace root so relative paths
+# target repository files instead of Bazel runfiles/symlinks.
+workspace_root = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+if workspace_root:
+    os.chdir(workspace_root)
 
 major, minor, release = VERSION_TUPLE
 release += 1
@@ -51,5 +58,8 @@ util.changelog.add_new_section(LOBSTER_VERSION)
 
 # Assemble commit
 
-os.system(f"git add CHANGELOG.md {VERSION_FILE}")
-os.system(f'git commit -m "Bump version to {LOBSTER_VERSION} after release"')
+subprocess.run(["git", "add", "CHANGELOG.md", VERSION_FILE], check=True)
+subprocess.run(
+    ["git", "commit", "-m", f"Bump version to {LOBSTER_VERSION} after release"],
+    check=True,
+)


### PR DESCRIPTION
- Updated [bump_version_post_release.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to replace deprecated os.system calls with subprocess.run for git add and git commit.
- Added Bazel-safe workspace handling in [bump_version_post_release.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) by switching to BUILD_WORKSPACE_DIRECTORY when present.
- This ensures the bump script updates real repository files ([CHANGELOG.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [version.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) during bazel run, avoiding runfiles/symlink-related git noise.