### PR TITLE
Narrow Workflow Permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   changes:
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       py_modified: ${{ steps.changed-py-files.outputs.any_modified }}
@@ -211,6 +212,7 @@ jobs:
       - run: bazel test //tests_system/... //tests_unit/...
   failure:
     name: Check all jobs
+    permissions: {}
     needs:
       - lint-code
       - lint-system-tests

--- a/.github/workflows/clang_tidy_cache.yml
+++ b/.github/workflows/clang_tidy_cache.yml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-clang-tidy-cache:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,6 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-permissions:
-  id-token: write
-  attestations: write
-  contents: write
-
 jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@1d798ff015ed0696433e01e2c3ccbb2abefadad7 # v7.7.0
@@ -43,6 +38,10 @@ jobs:
   publish:
     needs: release
     uses: ./.github/workflows/publish.yml
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
       registry_fork: ${{ inputs.registry_fork || 'bmw-software-engineering/bazel-central-registry' }}


### PR DESCRIPTION
Added permissions to `clang_tidy_cache.yml`, otherwise it checks out repository code but does not declare token permissions. Its effective permissions therefore would depend on the repository or organization default. If that default was read/write, this manually dispatched workflow receives more access than necessary.

Added read permissions explicitly in `ci.yml`. It works without the read permission, too, because the repository is private. But it would fail for any private repository copy. Limited permissions where permissions where too broad.

Streamlined permissions in `release.yml`.