### PR TITLE
Make `tracing.sh` fail fast and preserve intermediate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.pyc
 .clwb/
+.venv
 .vscode
 .envrc
 bazel-*

--- a/tracing/tracing.sh
+++ b/tracing/tracing.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
 
-# Create output directories if they don't exist
-mkdir -p tracing_out
-mkdir -p docs
+set -Eeuo pipefail
+
+export PYTHONPATH="${PYTHONPATH:-.}:$PWD"
+
+CURRENT_TOOL="setup"
+CURRENT_PHASE="create output directories"
+
+trap 'printf "❌ ERROR: tool %s failed during phase: %s\n" "$CURRENT_TOOL" "$CURRENT_PHASE" >&2' ERR
+
+mkdir -p tracing_out docs
 
 TOOLS=("codebeamer" "cpptest" "trlc" "json" "pkg" "report" "html_report" "online_report")
 
-# Process each tool
 for tool in "${TOOLS[@]}"; do
+    # delete all top-level files in tracing_out, but keep nested files
+    find tracing_out -maxdepth 1 -type f -delete
+
+    CURRENT_TOOL="$tool"
+    CURRENT_PHASE="resolve tool path"
     echo "Processing tool: lobster-$tool"
     TARGET_NAME="lobster_$tool"
 
@@ -19,63 +30,78 @@ for tool in "${TOOLS[@]}"; do
         TOOL_PATH="core/$tool"
         OUTPUT_NAME="tracing-core_$tool.html"
     else
-        echo "❌ ERROR: Tool '$tool' not found in lobster/tools/ or lobster/tools/core/"
-        continue
+        printf "ERROR: tool %s failed during phase: %s (not found in lobster/tools/ or lobster/tools/core/)\n" \
+            "$tool" "$CURRENT_PHASE" >&2
+        exit 1
     fi
 
-    # Process tool in a subshell to contain errors
-    if (
-        set -e  # Exit subshell on error, but don't exit main script
+    CURRENT_PHASE="generate list of relevant use cases"
+    python util/tracing/usecases.py \
+        --target="$TARGET_NAME" \
+        lobster/requirements.rsl \
+        lobster/use_cases.trlc \
+        "lobster/tools/$TOOL_PATH/requirements/potential_errors.trlc" \
+        "lobster/tools/$TOOL_PATH/requirements/test_specifications.trlc" \
+        --out="tracing_out/use-cases.lobster"
 
-        # Generate use cases
-        python util/tracing/usecases.py \
-            --target="$TARGET_NAME" \
-            lobster/requirements.rsl \
-            lobster/use_cases.trlc \
-            "lobster/tools/$TOOL_PATH/requirements/potential_errors.trlc" \
-            "lobster/tools/$TOOL_PATH/requirements/test_specifications.trlc" \
-            --out=tracing_out/use-cases.lobster
+    for artifact in potential-errors test-specifications system-requirements software-requirements; do
+        CURRENT_PHASE="generate $artifact artifact"
+        python lobster-trlc.py \
+            --config="tracing/lobster_$tool/$tool.$artifact.lobster-trlc.yaml" \
+            --out="tracing_out/$artifact.lobster"
+    done
 
-        # Generate artifacts
-        for artifact in potential-errors test-specifications system-requirements software-requirements; do
-            python lobster-trlc.py \
-                --config="tracing/lobster_$tool/$tool.$artifact.lobster-trlc.yaml" \
-                --out="tracing_out/$artifact.lobster"
-        done
+    CURRENT_PHASE="generate implementation traces"
+    python lobster-python.py "lobster/tools/$TOOL_PATH" --out="tracing_out/code.lobster"
+    CURRENT_PHASE="generate system test traces"
+    python lobster-python.py "tests_system/lobster_$tool" --activity \
+        --out="tracing_out/system-tests.lobster"
+    CURRENT_PHASE="generate unit test traces"
+    python lobster-python.py "tests_unit/lobster_$tool" --activity \
+        --out="tracing_out/unit-tests.lobster"
 
-        python lobster-python.py "lobster/tools/$TOOL_PATH" --out=tracing_out/code.lobster
-        python lobster-python.py tests_system/lobster_$tool --activity \
-            --out=tracing_out/system-tests.lobster
-        python lobster-python.py tests_unit/lobster_$tool --activity \
-            --out=tracing_out/unit-tests.lobster
+    CURRENT_PHASE="generate report"
+    python lobster-report.py --lobster-config=tracing/tracing_policy.conf \
+        --out="tracing_out/tracing.lobster"
 
-        # Generate report
-        python lobster-report.py --lobster-config=tracing/tracing_policy.conf \
-            --out=tracing_out/tracing.lobster
+    CURRENT_PHASE="create online report configuration"
+    # obtain repository remote URL
+    BASE_URL="$(git remote get-url origin)"
+    case "$BASE_URL" in
+        git@github.com:*) BASE_URL="https://github.com/${BASE_URL#git@github.com:}" ;;
+        ssh://git@github.com/*) BASE_URL="https://github.com/${BASE_URL#ssh://git@github.com/}" ;;
+    esac
+    # remove .git suffix
+    BASE_URL="${BASE_URL%.git}"
+    printf "report: tracing_out/tracing.lobster\n" > "tracing_out/online_report_config.yaml"
+    printf "commit_id: 'main'\n" >> "tracing_out/online_report_config.yaml"
+    printf "repo_root: ''\n" >> "tracing_out/online_report_config.yaml"
+    printf "base_url: '%s'\n" "$BASE_URL" >> "tracing_out/online_report_config.yaml"
 
-        # Generate online report
-        printf "report: tracing_out/tracing.lobster\n" >> tracing_out/online_report_config.yaml
-        printf "commit_id: 'main'\n" >> tracing_out/online_report_config.yaml
-        printf "repo_root: ''\n" >> tracing_out/online_report_config.yaml
-        printf "base_url: 'https://github.com/bmw-software-engineering/lobster'" >> tracing_out/online_report_config.yaml
-        python lobster-online-report.py --config=tracing_out/online_report_config.yaml --out=tracing_out/online-report.lobster
+    CURRENT_PHASE="generate online report"
+    python lobster-online-report.py \
+        --config="tracing_out/online_report_config.yaml" \
+        --out="tracing_out/online-report.lobster"
 
-        # Generate HTML reports
-        python lobster-html-report.py tracing_out/online-report.lobster \
-            --out=docs/$OUTPUT_NAME
-    ); then
-        echo -e "✅ SUCCESS: Generated HTML report for $tool in docs/$OUTPUT_NAME"
-        rm -f tracing_out/*.lobster tracing_out/*.yaml
-    else
-        echo -e "❌ ERROR: Failed to process $tool."
-        rm -f tracing_out/*.lobster tracing_out/*.yaml
-    fi
+    CURRENT_PHASE="generate HTML report"
+    python lobster-html-report.py "tracing_out/online-report.lobster" \
+        --out="tracing_out/$OUTPUT_NAME"
+
+    CURRENT_PHASE="copy reports to docs"
+    cp "tracing_out/$OUTPUT_NAME" "docs/$OUTPUT_NAME"
+    EVIDENCE_LOBSTER="${OUTPUT_NAME%.html}.lobster"
+    cp "tracing_out/online-report.lobster" "docs/$EVIDENCE_LOBSTER"
+
+    CURRENT_PHASE="move generated files to tool-specific folder"
+    TOOL_OUTPUT_DIR="tracing_out/$tool"
+    rm -rf "$TOOL_OUTPUT_DIR"
+    mkdir -p "$TOOL_OUTPUT_DIR"
+    mv tracing_out/*.lobster "tracing_out/$OUTPUT_NAME" "$TOOL_OUTPUT_DIR/"
+
+
+    printf "SUCCESS: generated HTML report for %s in docs/%s\n" "$tool" "$OUTPUT_NAME"
 
     echo "----------------------------------------"
 done
 
 echo "Tracing script completed"
-
-# Final cleanup - remove the entire tracing_out directory
-echo "Cleaning up intermediate files..."
-rm -rf tracing_out


### PR DESCRIPTION
Behavioral changes of `tracing/tracing.sh`:

- Fails immediately on any error. The script then prints an error message that mentions the current script phase (e.g. "generate use cases") and exits.
- Do not delete the `tracing_out` folder at the end of the run. The script still copies the HTML reports to the `docs` folder, but preserves the *.lobster files of each LOBSTER tool inside a tool-specific folder in `tracing_out`.

Both changes are helpful when using AI to work on the repository. AI gets confused easily if scripts swallow errors silently (so do humans). And AI can read the `tracing.lobster` files better than HTML tracing reports.

Furthermore the script now fetches the repository URL from `git` instead of using a hard-coded reference to the BMW GitHub organization. This way the script should also succeed in repository forks.