### PR TITLE
Auto-clean `tracing_out`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ test_install_monolithic_venv
 *.lobster
 *.html
 .idea
+
+# Tracing script output path
+tracing_out

--- a/tracing/tracing.sh
+++ b/tracing/tracing.sh
@@ -9,6 +9,7 @@ CURRENT_PHASE="create output directories"
 
 trap 'printf "❌ ERROR: tool %s failed during phase: %s\n" "$CURRENT_TOOL" "$CURRENT_PHASE" >&2' ERR
 
+rm -rf tracing_out
 mkdir -p tracing_out docs
 
 TOOLS=("codebeamer" "cpptest" "trlc" "json" "pkg" "report" "html_report" "online_report")


### PR DESCRIPTION
Updated the `tracing.sh` script so that it deletes the `tracing_out`
folder first, and recreates it, before creating the LOBSTER reports
in there.

Included `tracing_out` in `.gitignore`.