### PR TITLE
Remove Potential Errors from Tracing Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### 1.0.7-dev
 
+* Reworked the requirements and the way use cases are traced.
+  This could impact your tool qualification strategy for ISO 26262.
+  Please check carefully.
+
 * `lobster-trlc`:
   - Added support for experimental feature TRLC Markdown which takes
   `.trlc.md` as a valid input file extension.

--- a/tracing/tracing_policy.conf
+++ b/tracing/tracing_policy.conf
@@ -2,16 +2,6 @@ requirements "Use Cases" {
   source: "tracing_out/use-cases.lobster";
 }
 
-requirements "Potential Errors" {
-  source: "tracing_out/potential-errors.lobster";
-  trace to: "Use Cases";
-}
-
-requirements "Test Specifications" {
-  source: "tracing_out/test-specifications.lobster";
-  trace to: "Potential Errors";
-}
-
 requirements "System Requirements" {
   source: "tracing_out/system-requirements.lobster";
   trace to: "Use Cases";
@@ -22,15 +12,9 @@ requirements "Software Requirements" {
   trace to: "System Requirements";
 }
 
-implementation "Code" {
-  source: "tracing_out/code.lobster";
-  trace to: "Software Requirements";
-}
-
 activity "System Tests" {
   source: "tracing_out/system-tests.lobster";
   trace to: "System Requirements";
-  trace to: "Test Specifications";
 }
 
 activity "Software Tests" {


### PR DESCRIPTION
The `tracing.sh` script generates the LOBSTER reports for most of the LOBSTER tools. The tracing policy now no longer considers the potential errors and test specifications.

NOTE: This PR should be merged once all potential errors are fully migrated to system requirements.